### PR TITLE
Automatically require semantic-ui-sass

### DIFF
--- a/lib/pgbouncerhero.rb
+++ b/lib/pgbouncerhero.rb
@@ -9,6 +9,8 @@ require "pgbouncerhero/engine" if defined?(Rails)
 # models
 require "pgbouncerhero/connection"
 
+require "semantic-ui-sass"
+
 module PgBouncerHero
   # settings
   class << self


### PR DESCRIPTION
This will enable users to remove the explicit inclusion of the
semantic-ui-sass gem in their Gemfile.