### PR TITLE
Reconnect stale PgBouncer connections

### DIFF
--- a/lib/pgbouncerhero.rb
+++ b/lib/pgbouncerhero.rb
@@ -62,5 +62,13 @@ module PgBouncerHero
         Hash[mapped]
       end
     end
+
+    def disconnect!
+      @groups&.each_value do |group|
+        group.databases.each(&:disconnect!)
+      end
+    end
   end
 end
+
+at_exit { PgBouncerHero.disconnect! }

--- a/lib/pgbouncerhero/database.rb
+++ b/lib/pgbouncerhero/database.rb
@@ -16,7 +16,16 @@ module PgBouncerHero
     end
 
     def connection
+      disconnect! if @connection && connection_invalid?(@connection)
       @connection ||= connection_model.new(host, port, user, password, dbname).connection
+    end
+
+    def disconnect!
+      @connection&.finish unless @connection&.finished?
+    rescue PG::Error
+      nil
+    ensure
+      @connection = nil
     end
 
     def host
@@ -40,6 +49,12 @@ module PgBouncerHero
     end
 
     private
+
+    def connection_invalid?(connection)
+      connection.finished? || connection.status != PG::CONNECTION_OK
+    rescue PG::Error
+      true
+    end
 
     def connection_model
       @connection_model ||= begin

--- a/test/database_test.rb
+++ b/test/database_test.rb
@@ -1,6 +1,21 @@
 require "test_helper"
 
 class DatabaseTest < Minitest::Test
+  FakeConnection = Struct.new(:status, :finished, :finish_calls) do
+    def initialize(status: PG::CONNECTION_OK, finished: false)
+      super(status, finished, 0)
+    end
+
+    def finished?
+      finished
+    end
+
+    def finish
+      self.finish_calls += 1
+      self.finished = true
+    end
+  end
+
   def setup
     config = {
       "test_group" => {
@@ -51,5 +66,55 @@ class DatabaseTest < Minitest::Test
     assert_nil database.host
     assert_nil database.port
     assert_nil database.connection
+  end
+
+  def test_connection_reuses_a_valid_connection
+    connection = FakeConnection.new
+    @database.instance_variable_set(:@connection, connection)
+
+    assert_same connection, @database.connection
+  end
+
+  def test_connection_replaces_a_connection_with_a_bad_status
+    stale_connection = FakeConnection.new(status: PG::CONNECTION_BAD)
+    replacement_connection = FakeConnection.new
+    @database.instance_variable_set(:@connection, stale_connection)
+
+    stub_connection_model(replacement_connection)
+
+    assert_same replacement_connection, @database.connection
+    assert_predicate stale_connection, :finished?
+    assert_equal 1, stale_connection.finish_calls
+  end
+
+  def test_connection_replaces_a_finished_connection
+    stale_connection = FakeConnection.new(finished: true)
+    replacement_connection = FakeConnection.new
+    @database.instance_variable_set(:@connection, stale_connection)
+
+    stub_connection_model(replacement_connection)
+
+    assert_same replacement_connection, @database.connection
+    assert_equal 0, stale_connection.finish_calls
+  end
+
+  def test_disconnect_closes_and_clears_the_connection
+    connection = FakeConnection.new
+    @database.instance_variable_set(:@connection, connection)
+
+    @database.disconnect!
+
+    assert_predicate connection, :finished?
+    assert_nil @database.instance_variable_get(:@connection)
+  end
+
+  private
+
+  def stub_connection_model(connection)
+    connection_model = Class.new do
+      define_method(:initialize) { |*| }
+      define_method(:connection) { connection }
+    end
+    @database.define_singleton_method(:connection_model) { connection_model }
   end
 end

--- a/test/pgbouncerhero_test.rb
+++ b/test/pgbouncerhero_test.rb
@@ -26,6 +26,21 @@ class PgBouncerHeroTest < Minitest::Test
     PgBouncerHero.instance_variable_set(:@groups, nil)
   end
 
+  def test_disconnect_closes_initialized_database_connections
+    disconnected = false
+    database = Object.new
+    database.define_singleton_method(:disconnect!) { disconnected = true }
+    group = Struct.new(:databases).new([ database ])
+    previous_groups = PgBouncerHero.instance_variable_get(:@groups)
+    PgBouncerHero.instance_variable_set(:@groups, { "test" => group })
+
+    PgBouncerHero.disconnect!
+
+    assert disconnected
+  ensure
+    PgBouncerHero.instance_variable_set(:@groups, previous_groups)
+  end
+
   def test_importmap_exists
     assert_kind_of Importmap::Map, PgBouncerHero.importmap
   end


### PR DESCRIPTION
## Summary

PgBouncerHero memoizes its raw PostgreSQL connection. Once that connection becomes finished or enters `PG::CONNECTION_BAD`, subsequent requests can continue receiving the stale object instead of establishing a new connection.

This change improves connection lifecycle handling:

- Validates a cached connection before returning it.
- Closes and clears finished or unhealthy connections so the next access reconnects.
- Adds an explicit `PgBouncerHero.disconnect!` hook.
- Closes initialized connections when the process exits.

## Verification

- Full test suite passes: 27 runs, 47 assertions, 0 failures.
- Added coverage for valid, bad, finished, replaced, and explicitly disconnected connections.
- Targeted RuboCop passes with no offenses.

