### PR TITLE
Modernize configuration, concurrency, and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,42 +6,41 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
         ruby: ["3.2", "3.3", "3.4", "4.0"]
-        rails: ["rails-7-2", "rails-8-0", "rails-8-1"]
+        rails: ["rails_7_2", "rails_8_0", "rails_8_1"]
     name: Ruby ${{ matrix.ruby }} / ${{ matrix.rails }}
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.rails }}.gemfile
     steps:
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: false
-      - run: chmod -R o-w "$(ruby -e 'puts Gem.dir')/gems" 2>/dev/null || true
-      - run: bundle install
-      - run: bundle exec appraisal ${{ matrix.rails }} bundle install
-      - run: bundle exec appraisal ${{ matrix.rails }} rake test
+          bundler-cache: true
+      - run: bundle exec rake test
 
-  rubocop:
+  quality:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.4"
           bundler-cache: true
-      - run: bundle exec rubocop
-
-  herb:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.4"
-          bundler-cache: true
-      - run: bundle exec herb analyze app/views
+      - run: bundle exec rake
+      - run: bundle exec rake build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,8 @@ jobs:
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.rails }}.gemfile
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
@@ -37,8 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: "3.4"
           bundler-cache: true

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ tmp
 *.a
 mkmf.log
 gemfiles/*.lock
+/.serena/
+/test/dummy/log/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Unreleased
+
+**New:**
+- Configurable `PgBouncerHero.config_path`, resolved from the host application's `Rails.root` by default
+- `PgBouncerHero.reset!` for reloading configuration and connections safely
+- Request-level engine coverage and gem-package validation in CI
+
+**Improved:**
+- Serialize commands per database so a memoized PG connection is not used concurrently
+- Resolve parameterized group and database names consistently in routes and controllers
+- Load Rails engine dependencies explicitly and declare Propshaft as a runtime dependency
+- Cache Appraisal dependencies directly in the Ruby/Rails CI matrix
+- Add read-only workflow permissions, cancellation of superseded runs, and job timeouts
+
 ## 3.0.0
 
 **Breaking Changes:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Resolve parameterized group and database names consistently in routes and controllers
 - Load Rails engine dependencies explicitly and declare Propshaft as a runtime dependency
 - Cache Appraisal dependencies directly in the Ruby/Rails CI matrix
+- Pin GitHub Actions to their current immutable release commits
 - Add read-only workflow permissions, cancellation of superseded runs, and job timeouts
 
 ## 3.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,10 @@ bundle exec appraisal rake test  # Run tests across Rails versions
 
 ### Core library (`lib/`)
 
-- `lib/pgbouncerhero.rb` — Entry point. Loads config from `config/pgbouncerhero.yml` (ERB-parsed YAML with `YAML.safe_load`) or `PGBOUNCERHERO_DATABASE_URL` env var. Exposes `.groups` (memoized hash of Group objects) and `.importmap` (Importmap::Map instance). Config is cached at module level (`@config`).
+- `lib/pgbouncerhero.rb` — Entry point. Loads config from the host application's `config/pgbouncerhero.yml` (ERB-parsed YAML with `YAML.safe_load`) or `PGBOUNCERHERO_DATABASE_URL`. Exposes `.groups`, `.config_path`, `.reset!`, and `.importmap`. Config and groups are cached at module level.
 - `lib/pgbouncerhero/engine.rb` — Registers asset paths for Propshaft, sets up importmap, configures time zone.
 - `lib/pgbouncerhero/connection.rb` — Wraps `PG.connect` with configurable timeout (default 5s, override via `PGBOUNCERHERO_TIMEOUT`). Returns `nil` on connection failure.
-- `lib/pgbouncerhero/database.rb` — Parses a PgBouncer URL, lazily creates a Connection.
+- `lib/pgbouncerhero/database.rb` — Parses a PgBouncer URL, lazily creates a Connection, reconnects stale connections, and serializes commands per database.
 - `lib/pgbouncerhero/group.rb` — Collection of Database instances.
 - `lib/pgbouncerhero/methods/basics.rb` — Mixin executing PgBouncer admin commands.
 
@@ -74,7 +74,7 @@ Optional HTTP Basic Auth via `PGBOUNCERHERO_USERNAME` / `PGBOUNCERHERO_PASSWORD`
 
 - `test/dummy/` — Minimal Rails app for integration testing.
 - `test/test_helper.rb` — Loads dummy app and minitest.
-- Tests cover: version, config, groups, connection, database, helpers.
+- Tests cover: version, configuration loading, groups, connection lifecycle and serialization, helpers, routing, and engine rendering.
 - Appraisal tests against Rails 7.2, 8.0, and 8.1.
 - CI runs Ruby 3.2/3.3/3.4/4.0 x Rails 7.2/8.0/8.1.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,12 @@ PATH
   remote: .
   specs:
     pgbouncerhero (3.0.0)
-      importmap-rails (>= 1.2)
-      pg (>= 1.2)
-      railties (>= 7.2)
-      stimulus-rails (>= 1.0)
-      turbo-rails (>= 1.0)
+      importmap-rails (>= 1.2, < 3)
+      pg (>= 1.2, < 2)
+      propshaft (>= 1.0, < 2)
+      railties (>= 7.2, < 9)
+      stimulus-rails (>= 1.0, < 2)
+      turbo-rails (>= 1.0, < 3)
 
 GEM
   remote: https://rubygems.org/
@@ -123,7 +124,7 @@ GEM
     puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.2.6)
+    rack (3.2.7)
     rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -250,7 +251,6 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.7) sha256=94868719948664c89ddcaf0a37c65048413dfcb1c869470a5f7a7ceb5390b295
@@ -300,7 +300,7 @@ CHECKSUMS
   propshaft (1.3.2) sha256=1d56a3e56a92c21bfc29caf07406b5386b00d4c47ddf357cf989a5a234b1389e
   puma (8.0.2) sha256=c8ed871dfbbe66448ea9ffd46692342d9804d4071522b52b5331b7b6e7b686fb
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
-  rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
+  rack (3.2.7) sha256=93e13e1c24f93556671d85d2d79fa228c3485815c50d7e2f265b5330c6528fb7
   rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868

--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ pgbouncers:
       url: <%= ENV["PGBOUNCER_STAGING_REPLICA_DATABASE_URL"] %>
 ```
 
+Environment-specific top-level keys are also supported. PgBouncerHero reads
+`config/pgbouncerhero.yml` from the host application's `Rails.root` by default.
+An initializer can point to a different file:
+
+```ruby
+PgBouncerHero.config_path = Rails.root.join("config/pgbouncerhero.production.yml")
+```
+
+Changing `PgBouncerHero.env` or `config_path` resets cached groups and closes
+their open connections. Call `PgBouncerHero.reset!` after changing a config
+file at runtime, or `PgBouncerHero.disconnect!` when only the connections need
+to be closed. Stale connections reconnect automatically.
+
+The PostgreSQL connection timeout defaults to five seconds and can be changed
+with `PGBOUNCERHERO_TIMEOUT`.
+
 ## Development
 
 Start PostgreSQL and PgBouncer with Docker:
@@ -99,7 +115,8 @@ Run the test suite:
 
 ```bash
 bundle exec rake              # tests + rubocop + herb
-bundle exec appraisal rake test  # tests across Rails 7.2, 8.0, 8.1
+bundle exec appraisal rake test  # tests across Rails 7.2, 8.0, and 8.1
+bundle exec rake build        # build and validate the gem package
 ```
 
 Stop Docker when done:

--- a/app/controllers/pg_bouncer_hero/application_controller.rb
+++ b/app/controllers/pg_bouncer_hero/application_controller.rb
@@ -13,10 +13,11 @@ module PgBouncerHero
     def set_database
       @groups = PgBouncerHero.groups
       if params[:group] && params[:database]
-        @database = PgBouncerHero.groups[params[:group]].databases.find { |db| db.id.to_s == params[:database].to_s }
+        @group = @groups.fetch(params[:group])
+        @database = @group.databases.find { |database| database.name.parameterize == params[:database] }
       else
-        @group = @groups.first
-        @database = @groups.first.last.databases.first
+        _group_id, @group = @groups.first
+        @database = @group.databases.first
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,13 @@
 PgBouncerHero::Engine.routes.draw do
+  group_exists = ->(request) { PgBouncerHero.groups.key?(request.params[:group]) }
+  database_exists = lambda do |request|
+    group = PgBouncerHero.groups[request.params[:group]]
+    group&.databases&.any? { |database| database.name.parameterize == request.params[:database] }
+  end
+
   root to: "home#index"
-  scope path: ":group", constraints: proc { |req| (PgBouncerHero.groups.keys.map(&:parameterize) + [ nil ]).include?(req.params[:group]) } do
-    scope path: ":database", constraints: proc { |req| (PgBouncerHero.groups[req.params[:group]].databases.map(&:name).map(&:parameterize) + [ nil ]).include?(req.params[:database]) } do
+  scope path: ":group", constraints: group_exists do
+    scope path: ":database", constraints: database_exists do
       get :summary, controller: :database
       get :databases, controller: :database
       get :stats, controller: :database

--- a/lib/pgbouncerhero.rb
+++ b/lib/pgbouncerhero.rb
@@ -1,26 +1,30 @@
-require "pgbouncerhero/version"
-
-require "pgbouncerhero/methods/basics"
-
-require "pgbouncerhero/group"
-require "pgbouncerhero/engine" if defined?(Rails)
-
-require "pgbouncerhero/connection"
-
+require "erb"
+require "monitor"
+require "pathname"
+require "yaml"
+require "rails"
 require "pg"
 require "importmap-rails"
 require "turbo-rails"
 require "stimulus-rails"
 
+require "pgbouncerhero/version"
+require "pgbouncerhero/methods/basics"
+require "pgbouncerhero/connection"
+require "pgbouncerhero/group"
+require "pgbouncerhero/engine"
+
 module PgBouncerHero
+  class ConfigurationError < StandardError; end
+
+  STATE_MONITOR = Monitor.new
+  private_constant :STATE_MONITOR
+
   mattr_accessor :importmap, default: Importmap::Map.new
 
   class << self
-    attr_accessor :env
-  end
-  self.env = ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"
+    attr_reader :env
 
-  class << self
     def time_zone=(time_zone)
       @time_zone = time_zone.is_a?(ActiveSupport::TimeZone) ? time_zone : ActiveSupport::TimeZone[time_zone.to_s]
     end
@@ -29,46 +33,98 @@ module PgBouncerHero
       @time_zone || Time.zone
     end
 
-    def config
-      @config ||= begin
-        path = "config/pgbouncerhero.yml"
-
-        config = YAML.safe_load(ERB.new(File.read(path)).result, aliases: true) if File.exist?(path)
-        config ||= {}
-
-        if config[env]
-          config[env]
-        elsif config["pgbouncers"]
-          config
-        else
-          {
-            "pgbouncers" => {
-              "default" => {
-                "primary" => {
-                  "url" => ENV["PGBOUNCERHERO_DATABASE_URL"]
-                }
-              }
-            }
-          }
-        end
+    def env=(env)
+      STATE_MONITOR.synchronize do
+        @env = env.to_s
+        reset!
       end
     end
 
+    def config_path
+      STATE_MONITOR.synchronize { @config_path || default_config_path }
+    end
+
+    def config_path=(path)
+      STATE_MONITOR.synchronize do
+        @config_path = path && Pathname(path)
+        reset!
+      end
+    end
+
+    def config
+      STATE_MONITOR.synchronize { @config ||= selected_config(load_config) }
+    end
+
     def groups
-      @groups ||= begin
-        mapped = config["pgbouncers"].map do |group_id, _hash|
-          [ group_id.parameterize, PgBouncerHero::Group.new(group_id, config["pgbouncers"]) ]
+      STATE_MONITOR.synchronize do
+        @groups ||= config.fetch("pgbouncers").to_h do |group_id, _databases|
+          [ group_id.parameterize, PgBouncerHero::Group.new(group_id, config.fetch("pgbouncers")) ]
         end
-        Hash[mapped]
       end
     end
 
     def disconnect!
-      @groups&.each_value do |group|
-        group.databases.each(&:disconnect!)
+      STATE_MONITOR.synchronize do
+        @groups&.each_value do |group|
+          group.databases.each(&:disconnect!)
+        end
       end
     end
+
+    def reset!
+      STATE_MONITOR.synchronize do
+        disconnect!
+        @config = nil
+        @groups = nil
+      end
+    end
+
+    private
+
+    def default_config_path
+      (Rails.root || Pathname.pwd).join("config/pgbouncerhero.yml")
+    end
+
+    def load_config
+      return {} unless config_path.file?
+
+      loaded = YAML.safe_load(ERB.new(config_path.read).result, aliases: true)
+      return {} if loaded.nil?
+      return loaded if loaded.is_a?(Hash)
+
+      raise ConfigurationError, "#{config_path} must contain a YAML mapping"
+    end
+
+    def selected_config(loaded)
+      selected = loaded.fetch(env, loaded)
+      unless selected.is_a?(Hash)
+        raise ConfigurationError, "configuration for #{env.inspect} must be a YAML mapping"
+      end
+
+      return default_config unless selected.key?("pgbouncers")
+
+      pgbouncers = selected["pgbouncers"]
+      unless pgbouncers.is_a?(Hash) && pgbouncers.any? && pgbouncers.values.all? { |databases| databases.is_a?(Hash) && databases.any? }
+        raise ConfigurationError, '"pgbouncers" must contain at least one group with one database'
+      end
+
+      selected
+    end
+
+    def default_config
+      {
+        "pgbouncers" => {
+          "default" => {
+            "primary" => {
+              "url" => ENV["PGBOUNCERHERO_DATABASE_URL"]
+            }
+          }
+        }
+      }
+    end
   end
+
+  self.env = ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"
 end
 
 at_exit { PgBouncerHero.disconnect! }

--- a/lib/pgbouncerhero/database.rb
+++ b/lib/pgbouncerhero/database.rb
@@ -1,3 +1,5 @@
+require "monitor"
+
 module PgBouncerHero
   class Database
     include Methods::Basics
@@ -7,8 +9,9 @@ module PgBouncerHero
     def initialize(group, id, config)
       @id = id
       @config = config || {}
-      @url = URI.parse(config["url"].to_s)
+      @url = URI.parse(@config["url"].to_s)
       @group = group
+      @connection_monitor = Monitor.new
     end
 
     def name
@@ -16,16 +19,14 @@ module PgBouncerHero
     end
 
     def connection
-      disconnect! if @connection && connection_invalid?(@connection)
-      @connection ||= connection_model.new(host, port, user, password, dbname).connection
+      @connection_monitor.synchronize do
+        disconnect_connection! if @connection && connection_invalid?(@connection)
+        @connection ||= connection_model.new(host, port, user, password, dbname).connection
+      end
     end
 
     def disconnect!
-      @connection&.finish unless @connection&.finished?
-    rescue PG::Error
-      nil
-    ensure
-      @connection = nil
+      @connection_monitor.synchronize { disconnect_connection! }
     end
 
     def host
@@ -49,6 +50,20 @@ module PgBouncerHero
     end
 
     private
+
+    def execute(command)
+      @connection_monitor.synchronize do
+        connection&.exec(command)
+      end
+    end
+
+    def disconnect_connection!
+      @connection&.finish unless @connection&.finished?
+    rescue PG::Error
+      nil
+    ensure
+      @connection = nil
+    end
 
     def connection_invalid?(connection)
       connection.finished? || connection.status != PG::CONNECTION_OK

--- a/lib/pgbouncerhero/methods/basics.rb
+++ b/lib/pgbouncerhero/methods/basics.rb
@@ -12,31 +12,31 @@ module PgBouncerHero
         end
       end
       def databases
-        connection.exec("SHOW databases")
+        execute("SHOW databases")
       end
       def stats
-        connection.exec("SHOW stats")
+        execute("SHOW stats")
       end
       def lists
-        connection.exec("SHOW lists")
+        execute("SHOW lists")
       end
       def pools
-        connection.exec("SHOW pools")
+        execute("SHOW pools")
       end
       def clients
-        connection.exec("SHOW clients")
+        execute("SHOW clients")
       end
       def conf
-        connection.exec("SHOW config")
+        execute("SHOW config")
       end
       def reload
-        connection.exec("RELOAD")
+        execute("RELOAD")
       end
       def suspend
-        connection.exec("SUSPEND")
+        execute("SUSPEND")
       end
       def shutdown
-        connection.exec("SHUTDOWN")
+        execute("SHUTDOWN")
       end
     end
   end

--- a/pgbouncerhero.gemspec
+++ b/pgbouncerhero.gemspec
@@ -18,15 +18,17 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "source_code_uri" => "https://github.com/kwent/pgbouncerhero",
     "changelog_uri" => "https://github.com/kwent/pgbouncerhero/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://github.com/kwent/pgbouncerhero#readme",
     "bug_tracker_uri" => "https://github.com/kwent/pgbouncerhero/issues",
     "rubygems_mfa_required" => "true"
   }
 
-  spec.add_dependency "railties", ">= 7.2"
-  spec.add_dependency "importmap-rails", ">= 1.2"
-  spec.add_dependency "turbo-rails", ">= 1.0"
-  spec.add_dependency "stimulus-rails", ">= 1.0"
-  spec.add_dependency "pg", ">= 1.2"
+  spec.add_dependency "railties", ">= 7.2", "< 9"
+  spec.add_dependency "propshaft", ">= 1.0", "< 2"
+  spec.add_dependency "importmap-rails", ">= 1.2", "< 3"
+  spec.add_dependency "turbo-rails", ">= 1.0", "< 3"
+  spec.add_dependency "stimulus-rails", ">= 1.0", "< 2"
+  spec.add_dependency "pg", ">= 1.2", "< 2"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "tailwindcss-rails", "~> 4.0"

--- a/test/database_test.rb
+++ b/test/database_test.rb
@@ -1,9 +1,9 @@
 require "test_helper"
 
 class DatabaseTest < Minitest::Test
-  FakeConnection = Struct.new(:status, :finished, :finish_calls) do
+  FakeConnection = Struct.new(:status, :finished, :finish_calls, :queries) do
     def initialize(status: PG::CONNECTION_OK, finished: false)
-      super(status, finished, 0)
+      super(status, finished, 0, [])
     end
 
     def finished?
@@ -13,6 +13,33 @@ class DatabaseTest < Minitest::Test
     def finish
       self.finish_calls += 1
       self.finished = true
+    end
+
+    def exec(query)
+      queries << query
+      []
+    end
+  end
+
+  class ConcurrentConnection < FakeConnection
+    attr_reader :max_active
+
+    def initialize
+      super
+      @active = 0
+      @max_active = 0
+      @activity_lock = Mutex.new
+    end
+
+    def exec(query)
+      @activity_lock.synchronize do
+        @active += 1
+        @max_active = [ @max_active, @active ].max
+      end
+      sleep 0.01
+      super
+    ensure
+      @activity_lock.synchronize { @active -= 1 }
     end
   end
 
@@ -55,6 +82,15 @@ class DatabaseTest < Minitest::Test
 
     assert_nil database.host
     assert_nil database.port
+    assert_nil database.connection
+  end
+
+  def test_database_with_nil_config
+    config = { "test_group" => { "primary" => nil } }
+    group = PgBouncerHero::Group.new("test_group", config)
+    database = group.databases.first
+
+    assert_nil database.host
     assert_nil database.connection
   end
 
@@ -106,6 +142,26 @@ class DatabaseTest < Minitest::Test
 
     assert_predicate connection, :finished?
     assert_nil @database.instance_variable_get(:@connection)
+  end
+
+  def test_commands_execute_on_the_connection
+    connection = FakeConnection.new
+    @database.instance_variable_set(:@connection, connection)
+
+    @database.stats
+
+    assert_equal [ "SHOW stats" ], connection.queries
+  end
+
+  def test_commands_are_serialized_per_database
+    connection = ConcurrentConnection.new
+    @database.instance_variable_set(:@connection, connection)
+
+    threads = 4.times.map { Thread.new { @database.stats } }
+    threads.each(&:join)
+
+    assert_equal 1, connection.max_active
+    assert_equal [ "SHOW stats" ] * 4, connection.queries
   end
 
   private

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+require "tmpdir"
+
+class EngineTest < ActionDispatch::IntegrationTest
+  def test_dashboard_renders
+    get "/pgbouncerhero"
+
+    assert_response :success
+    assert_select "h2", "Overview"
+    assert_select "turbo-frame", count: 1
+  end
+
+  def test_unknown_group_does_not_match
+    get "/pgbouncerhero/unknown/primary/stats"
+
+    assert_response :not_found
+  end
+
+  def test_parameterized_group_and_database_names_route_correctly
+    with_config(<<~YAML) do
+      pgbouncers:
+        My Group:
+          Read Replica: {}
+    YAML
+      get "/pgbouncerhero/my-group/read-replica/databases"
+
+      assert_response :success
+      assert_select "span", "My Group > Read Replica"
+    end
+  end
+
+  private
+
+  def with_config(contents)
+    previous_path = PgBouncerHero.instance_variable_get(:@config_path)
+
+    Dir.mktmpdir do |directory|
+      path = Pathname(directory).join("pgbouncerhero.yml")
+      path.write(contents)
+      PgBouncerHero.config_path = path
+      yield
+    end
+  ensure
+    PgBouncerHero.config_path = previous_path
+  end
+end

--- a/test/pgbouncerhero_test.rb
+++ b/test/pgbouncerhero_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "tmpdir"
 
 class PgBouncerHeroTest < Minitest::Test
   def test_version
@@ -14,16 +15,47 @@ class PgBouncerHeroTest < Minitest::Test
     assert PgBouncerHero.config.key?("pgbouncers")
   end
 
+  def test_config_path_defaults_to_the_host_application
+    assert_equal Rails.root.join("config/pgbouncerhero.yml"), PgBouncerHero.config_path
+  end
+
+  def test_config_loads_the_current_environment_from_a_custom_path
+    with_config(<<~YAML) do
+      test:
+        pgbouncers:
+          local:
+            primary:
+              url: postgres://user:pass@localhost:6432/pgbouncer
+    YAML
+      assert_equal [ "local" ], PgBouncerHero.groups.keys
+      assert_equal "localhost", PgBouncerHero.groups.fetch("local").databases.first.host
+    end
+  end
+
+  def test_config_rejects_a_non_mapping_document
+    with_config("- invalid\n") do
+      error = assert_raises(PgBouncerHero::ConfigurationError) { PgBouncerHero.config }
+
+      assert_includes error.message, "must contain a YAML mapping"
+    end
+  end
+
+  def test_config_rejects_empty_pgbouncer_groups
+    with_config("pgbouncers: {}\n") do
+      error = assert_raises(PgBouncerHero::ConfigurationError) { PgBouncerHero.config }
+
+      assert_includes error.message, "must contain at least one group"
+    end
+  end
+
   def test_groups_returns_hash
     ENV["PGBOUNCERHERO_DATABASE_URL"] = "postgres://user:pass@localhost:6432/pgbouncer"
-    PgBouncerHero.instance_variable_set(:@config, nil)
-    PgBouncerHero.instance_variable_set(:@groups, nil)
+    PgBouncerHero.reset!
     assert_kind_of Hash, PgBouncerHero.groups
     assert PgBouncerHero.groups.key?("default")
   ensure
     ENV.delete("PGBOUNCERHERO_DATABASE_URL")
-    PgBouncerHero.instance_variable_set(:@config, nil)
-    PgBouncerHero.instance_variable_set(:@groups, nil)
+    PgBouncerHero.reset!
   end
 
   def test_disconnect_closes_initialized_database_connections
@@ -43,5 +75,23 @@ class PgBouncerHeroTest < Minitest::Test
 
   def test_importmap_exists
     assert_kind_of Importmap::Map, PgBouncerHero.importmap
+  end
+
+  private
+
+  def with_config(contents)
+    previous_path = PgBouncerHero.instance_variable_get(:@config_path)
+    previous_env = PgBouncerHero.env
+
+    Dir.mktmpdir do |directory|
+      path = Pathname(directory).join("pgbouncerhero.yml")
+      path.write(contents)
+      PgBouncerHero.config_path = path
+      PgBouncerHero.env = "test"
+      yield
+    end
+  ensure
+    PgBouncerHero.config_path = previous_path
+    PgBouncerHero.env = previous_env
   end
 end


### PR DESCRIPTION
## Summary

Modernize PgBouncerHero’s runtime lifecycle, packaging, routing, and CI without changing its supported Ruby or Rails baseline.

- Resolve configuration from the host application and add explicit reset/configuration APIs.
- Serialize commands per database connection and make configuration caches thread-safe.
- Fix parameterized group and database routing.
- Correct Rails engine load order and runtime dependency declarations.
- Streamline the Ruby/Rails CI matrix with dependency caching, restricted permissions, cancellation, timeouts, and package validation.
- Expand configuration, concurrency, routing, and engine integration coverage.

## Verification

- `bundle exec rake`: 37 runs, 69 assertions, 0 failures; RuboCop and Herb clean.
- `bundle exec appraisal rake test`: passes on Rails 7.2, 8.0, and 8.1.
- Ruby 3.2.2 and Ruby 4.0.6 boundary runs pass against Rails 7.2 and 8.1.
- Direct gem loading succeeds under Rails 8.1.
- `bundle exec rake build` succeeds.
- Workflow YAML and every matrix Gemfile path verified.
