### PR TITLE
Add real PgBouncer integration coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,13 @@ updates:
         update-types:
           - minor
           - patch
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,3 +44,25 @@ jobs:
           bundler-cache: true
       - run: bundle exec rake
       - run: bundle exec rake build
+
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - name: Start PostgreSQL and PgBouncer
+        run: docker compose up --detach --wait --wait-timeout 60
+      - name: Run PgBouncer integration tests
+        run: bundle exec rake test:integration
+        env:
+          PGBOUNCERHERO_INTEGRATION_URL: postgres://pgbouncer:pgbouncer@127.0.0.1:6432/pgbouncer
+      - name: Show container logs after a failure
+        if: failure()
+        run: docker compose logs
+      - name: Stop PostgreSQL and PgBouncer
+        if: always()
+        run: docker compose down --volumes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 ## Unreleased
 
 **New:**
+- Real PgBouncer integration coverage for admin queries, summaries, reloads, authentication, and reconnection
+- A dedicated CI integration job backed by the repository's Docker Compose stack
 - Configurable `PgBouncerHero.config_path`, resolved from the host application's `Rails.root` by default
 - `PgBouncerHero.reset!` for reloading configuration and connections safely
 - Request-level engine coverage and gem-package validation in CI
 
 **Improved:**
+- Pin PostgreSQL and PgBouncer development images and wait for container health before testing
+- Let Dependabot maintain Docker image versions alongside gems and GitHub Actions
 - Serialize commands per database so a memoized PG connection is not used concurrently
 - Resolve parameterized group and database names consistently in routes and controllers
 - Load Rails engine dependencies explicitly and declare Propshaft as a runtime dependency

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ bundle exec rake              # Run all (test + rubocop + herb:lint)
 gem build pgbouncerhero.gemspec  # Build the gem
 bundle exec appraisal install    # Install Appraisal gemfiles
 bundle exec appraisal rake test  # Run tests across Rails versions
+bundle exec rake test:integration # Run real PgBouncer tests after docker compose up -d --wait
 ```
 
 ## Architecture
@@ -74,7 +75,8 @@ Optional HTTP Basic Auth via `PGBOUNCERHERO_USERNAME` / `PGBOUNCERHERO_PASSWORD`
 
 - `test/dummy/` — Minimal Rails app for integration testing.
 - `test/test_helper.rb` — Loads dummy app and minitest.
-- Tests cover: version, configuration loading, groups, connection lifecycle and serialization, helpers, routing, and engine rendering.
+- Unit tests cover: version, configuration loading, groups, connection lifecycle and serialization, helpers, routing, and engine rendering.
+- `test/integration/` exercises real PgBouncer admin queries, summaries, reloads, authentication, and reconnection against the Docker Compose stack.
 - Appraisal tests against Rails 7.2, 8.0, and 8.1.
 - CI runs Ruby 3.2/3.3/3.4/4.0 x Rails 7.2/8.0/8.1.
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ with `PGBOUNCERHERO_TIMEOUT`.
 Start PostgreSQL and PgBouncer with Docker:
 
 ```bash
-docker compose up -d
+docker compose up --detach --wait
 ```
 
 Run the dummy Rails app:
@@ -114,15 +114,20 @@ Then open http://localhost:3000/pgbouncerhero.
 Run the test suite:
 
 ```bash
-bundle exec rake              # tests + rubocop + herb
+bundle exec rake                 # unit/integration-free tests + rubocop + herb
 bundle exec appraisal rake test  # tests across Rails 7.2, 8.0, and 8.1
-bundle exec rake build        # build and validate the gem package
+bundle exec rake build           # build and validate the gem package
+bundle exec rake test:integration # real PgBouncer admin-console tests
 ```
+
+The integration task expects PostgreSQL and PgBouncer from the Compose stack.
+Override `PGBOUNCERHERO_INTEGRATION_URL` to test another PgBouncer instance.
+The default is `postgres://pgbouncer:pgbouncer@127.0.0.1:6432/pgbouncer`.
 
 Stop Docker when done:
 
 ```bash
-docker compose down
+docker compose down --volumes
 ```
 
 ## Contributing

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,15 @@ require "rubocop/rake_task"
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList["test/**/*_test.rb"]
+  t.test_files = FileList["test/**/*_test.rb"].exclude("test/integration/**/*")
+end
+
+namespace :test do
+  Rake::TestTask.new(:integration) do |t|
+    t.libs << "test"
+    t.libs << "lib"
+    t.test_files = FileList["test/integration/**/*_test.rb"]
+  end
 end
 
 RuboCop::RakeTask.new

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,23 @@
 services:
   postgres:
-    image: postgres:17
+    image: postgres:17.11-alpine
     environment:
       POSTGRES_USER: pgbouncer
       POSTGRES_PASSWORD: pgbouncer
       POSTGRES_DB: app
     ports:
       - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U pgbouncer -d app"]
+      interval: 2s
+      timeout: 5s
+      retries: 15
 
   pgbouncer:
-    image: edoburu/pgbouncer:latest
+    image: edoburu/pgbouncer:v1.25.2-p0
     environment:
       DATABASE_URL: postgres://pgbouncer:pgbouncer@postgres:5432/app
-      AUTH_TYPE: trust
+      AUTH_TYPE: scram-sha-256
       IGNORE_STARTUP_PARAMETERS: extra_float_digits
       ADMIN_USERS: pgbouncer
       MAX_CLIENT_CONN: 100
@@ -20,4 +25,10 @@ services:
     ports:
       - "6432:5432"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -p 5432 -U pgbouncer -d pgbouncer"]
+      interval: 2s
+      timeout: 5s
+      retries: 15

--- a/test/integration/pgbouncer_test.rb
+++ b/test/integration/pgbouncer_test.rb
@@ -1,0 +1,80 @@
+require "test_helper"
+
+class PgBouncerIntegrationTest < Minitest::Test
+  URL = ENV.fetch(
+    "PGBOUNCERHERO_INTEGRATION_URL",
+    "postgres://pgbouncer:pgbouncer@127.0.0.1:6432/pgbouncer"
+  )
+
+  def setup
+    config = {
+      "integration" => {
+        "primary" => { "url" => URL }
+      }
+    }
+    @database = PgBouncerHero::Group.new("integration", config).databases.first
+  end
+
+  def teardown
+    @database.disconnect!
+  end
+
+  def test_connects_to_the_pgbouncer_admin_console
+    result = @database.connection.exec("SHOW VERSION")
+
+    assert_match(/\APgBouncer \d+\.\d+\.\d+/, result.first.fetch("version"))
+    assert_equal PG::CONNECTION_OK, @database.connection.status
+  end
+
+  def test_executes_dashboard_queries_against_pgbouncer
+    results = {
+      databases: @database.databases,
+      stats: @database.stats,
+      lists: @database.lists,
+      pools: @database.pools,
+      clients: @database.clients,
+      config: @database.conf
+    }
+
+    results.each_value { |result| assert_instance_of PG::Result, result }
+    assert_includes results.fetch(:databases).map { |row| row.fetch("name") }, "app"
+    assert_includes results.fetch(:config).map { |row| row.fetch("key") }, "listen_port"
+  end
+
+  def test_builds_a_summary_from_real_results
+    summary = @database.summary
+    database_details = summary.find { |row| row.key?(:databases_details) }
+
+    assert database_details
+    assert_includes database_details.fetch(:databases_details).map { |row| row.fetch("name") }, "app"
+    refute_includes database_details.fetch(:databases_details).map { |row| row.fetch("name") }, "pgbouncer"
+  end
+
+  def test_reconnects_after_the_connection_is_finished
+    original = @database.connection
+    original.finish
+
+    replacement = @database.connection
+
+    refute_same original, replacement
+    assert_equal PG::CONNECTION_OK, replacement.status
+  end
+
+  def test_reload_keeps_the_admin_console_available
+    result = @database.reload
+
+    assert_equal PG::PGRES_COMMAND_OK, result.result_status
+    assert_instance_of PG::Result, @database.stats
+  end
+
+  def test_rejects_invalid_credentials
+    invalid_url = URI(URL).dup
+    invalid_url.password = "incorrect"
+    config = { "integration" => { "invalid" => { "url" => invalid_url.to_s } } }
+    database = PgBouncerHero::Group.new("integration", config).databases.first
+
+    assert_nil database.connection
+  ensure
+    database&.disconnect!
+  end
+end


### PR DESCRIPTION
## Summary

Add a real PostgreSQL + PgBouncer integration boundary before changing connection management further.

- Add a dedicated `test:integration` Rake task that remains separate from the fast unit/Rails matrix.
- Exercise the PgBouncer admin console, dashboard queries, summary shaping, reload, rejected credentials, and stale-connection replacement.
- Add a health-checked CI integration job using the same Docker Compose stack as local development.
- Pin PostgreSQL 17.11 and PgBouncer 1.25.2 development images.
- Let Dependabot maintain Docker image versions.

## Verification

- `bundle exec rake`: 37 runs, 69 assertions, 0 failures; RuboCop and Herb clean.
- `bundle exec rake test:integration`: 6 runs, 23 assertions, 0 failures against the live Compose stack.
- Workflow, Dependabot, and Docker Compose configuration parse successfully.
- Container health gating, failure logs, and unconditional cleanup are configured in CI.
