### PR TITLE
Add bounded connection pooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 **New:**
+- Bounded, thread-safe connection pools per PgBouncer with configurable size and checkout timeout
+- Explicit `Database#with_connection` leases for running multiple commands on one connection
 - Real PgBouncer integration coverage for admin queries, summaries, reloads, authentication, and reconnection
 - A dedicated CI integration job backed by the repository's Docker Compose stack
 - Configurable `PgBouncerHero.config_path`, resolved from the host application's `Rails.root` by default
@@ -8,9 +10,10 @@
 - Request-level engine coverage and gem-package validation in CI
 
 **Improved:**
+- Reconnect stale or failed pooled connections automatically and close every pool on reset
 - Pin PostgreSQL and PgBouncer development images and wait for container health before testing
 - Let Dependabot maintain Docker image versions alongside gems and GitHub Actions
-- Serialize commands per database so a memoized PG connection is not used concurrently
+- Protect PgBouncer connections from concurrent use while allowing bounded parallel queries
 - Resolve parameterized group and database names consistently in routes and controllers
 - Load Rails engine dependencies explicitly and declare Propshaft as a runtime dependency
 - Cache Appraisal dependencies directly in the Ruby/Rails CI matrix

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,8 @@ bundle exec rake test:integration # Run real PgBouncer tests after docker compos
 
 - `lib/pgbouncerhero.rb` — Entry point. Loads config from the host application's `config/pgbouncerhero.yml` (ERB-parsed YAML with `YAML.safe_load`) or `PGBOUNCERHERO_DATABASE_URL`. Exposes `.groups`, `.config_path`, `.reset!`, and `.importmap`. Config and groups are cached at module level.
 - `lib/pgbouncerhero/engine.rb` — Registers asset paths for Propshaft, sets up importmap, configures time zone.
-- `lib/pgbouncerhero/connection.rb` — Wraps `PG.connect` with configurable timeout (default 5s, override via `PGBOUNCERHERO_TIMEOUT`). Returns `nil` on connection failure.
-- `lib/pgbouncerhero/database.rb` — Parses a PgBouncer URL, lazily creates a Connection, reconnects stale connections, and serializes commands per database.
+- `lib/pgbouncerhero/connection.rb` — Wraps `PG.connect` with configurable timeout (default 5s, override via `PGBOUNCERHERO_TIMEOUT`), validates connections before reuse, and reconnects after failures.
+- `lib/pgbouncerhero/database.rb` — Parses a PgBouncer URL and owns a bounded, lazy connection pool per PgBouncer. Pool size and checkout timeout default to 5 and are configurable globally or per database.
 - `lib/pgbouncerhero/group.rb` — Collection of Database instances.
 - `lib/pgbouncerhero/methods/basics.rb` — Mixin executing PgBouncer admin commands.
 
@@ -75,8 +75,8 @@ Optional HTTP Basic Auth via `PGBOUNCERHERO_USERNAME` / `PGBOUNCERHERO_PASSWORD`
 
 - `test/dummy/` — Minimal Rails app for integration testing.
 - `test/test_helper.rb` — Loads dummy app and minitest.
-- Unit tests cover: version, configuration loading, groups, connection lifecycle and serialization, helpers, routing, and engine rendering.
-- `test/integration/` exercises real PgBouncer admin queries, summaries, reloads, authentication, and reconnection against the Docker Compose stack.
+- Unit tests cover: version, configuration loading, groups, pooled connection lifecycle and concurrency, helpers, routing, and engine rendering.
+- `test/integration/` exercises real PgBouncer admin queries, summaries, reloads, authentication, reconnection, and concurrent pooled checkouts against the Docker Compose stack.
 - Appraisal tests against Rails 7.2, 8.0, and 8.1.
 - CI runs Ruby 3.2/3.3/3.4/4.0 x Rails 7.2/8.0/8.1.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     pgbouncerhero (3.0.0)
+      connection_pool (>= 3.0, < 4)
       importmap-rails (>= 1.2, < 3)
       pg (>= 1.2, < 2)
       propshaft (>= 1.0, < 2)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ pgbouncers:
   production:
     primary:
       url: <%= ENV["PGBOUNCER_PRODUCTION_PRIMARY_DATABASE_URL"] %>
+      pool_size: 5
+      pool_timeout: 5
     replica:
       url: <%= ENV["PGBOUNCER_PRODUCTION_REPLICA_DATABASE_URL"] %>
   staging:
@@ -93,6 +95,27 @@ to be closed. Stale connections reconnect automatically.
 
 The PostgreSQL connection timeout defaults to five seconds and can be changed
 with `PGBOUNCERHERO_TIMEOUT`.
+
+PgBouncerHero keeps a bounded, lazily created connection pool for each
+configured PgBouncer. The pool defaults to five connections with a five-second
+checkout timeout. Set `PGBOUNCERHERO_POOL_SIZE` and
+`PGBOUNCERHERO_POOL_TIMEOUT` to change the defaults for every PgBouncer, or set
+`pool_size` and `pool_timeout` on an individual database entry as shown above.
+Per-database settings take precedence over environment variables.
+
+Code that needs to issue multiple commands on the same PostgreSQL connection
+can lease one explicitly:
+
+```ruby
+database.with_connection do |connection|
+  connection.exec("SHOW VERSION")
+  connection.exec("SHOW CONFIG")
+end
+```
+
+`database.connection` remains available as a connection-compatible proxy for
+existing integrations. Connections are checked when borrowed, and stale or
+failed connections are discarded and recreated automatically.
 
 ## Development
 

--- a/lib/generators/pgbouncerhero/templates/config.yml
+++ b/lib/generators/pgbouncerhero/templates/config.yml
@@ -3,6 +3,8 @@ pgbouncers:
     primary:
       # eg. postgres://user:password@host:port/pgbouncer
       # url: <%%= ENV["PGBOUNCER_PRODUCTION_PRIMARY_DATABASE_URL"] %>
+      # pool_size: 5
+      # pool_timeout: 5
     # Add more databases
     # replica:
     #   url: <%%= ENV["PGBOUNCER_PRODUCTION_REPLICA_DATABASE_URL"] %>

--- a/lib/pgbouncerhero/connection.rb
+++ b/lib/pgbouncerhero/connection.rb
@@ -10,19 +10,60 @@ module PgBouncerHero
     end
 
     def connection
-      @connection ||= begin
-        PG.connect(
-          host: @host,
-          port: @port,
-          user: @user,
-          password: @password,
-          dbname: @dbname,
-          connect_timeout: @timeout
-        )
-      rescue StandardError => e
-        Rails.logger.error("[PGBouncerHero] Host:#{@host} | Database Name:#{@dbname} | Timeout: #{@timeout}s => #{e}")
-        nil
-      end
+      disconnect! if @connection && connection_invalid?(@connection)
+      @connection ||= connect
+    rescue StandardError => e
+      Rails.logger.error("[PGBouncerHero] Host:#{@host} | Database Name:#{@dbname} | Timeout: #{@timeout}s => #{e}")
+      nil
+    end
+
+    def connected?
+      !connection.nil?
+    end
+
+    def with_connection
+      raw_connection = connection
+      return unless raw_connection
+
+      yield raw_connection
+    rescue PG::Error
+      disconnect!
+      raise
+    end
+
+    def disconnect!
+      @connection&.finish unless @connection&.finished?
+    rescue PG::Error
+      nil
+    ensure
+      @connection = nil
+    end
+
+    def method_missing(method_name, *, **, &)
+      with_connection { |raw_connection| raw_connection.public_send(method_name, *, **, &) }
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      PG::Connection.public_instance_methods(include_private).include?(method_name) || super
+    end
+
+    private
+
+    def connect
+      PG.connect(
+        host: @host,
+        port: @port,
+        user: @user,
+        password: @password,
+        dbname: @dbname,
+        connect_timeout: @timeout
+      )
+    end
+
+    def connection_invalid?(connection)
+      connection.finished? || connection.status != PG::CONNECTION_OK
+    rescue PG::Error
+      true
     end
   end
 end

--- a/lib/pgbouncerhero/database.rb
+++ b/lib/pgbouncerhero/database.rb
@@ -1,17 +1,23 @@
+require "connection_pool"
 require "monitor"
 
 module PgBouncerHero
   class Database
     include Methods::Basics
 
-    attr_reader :id, :config, :group
+    DEFAULT_POOL_SIZE = 5
+    DEFAULT_POOL_TIMEOUT = 5
+
+    attr_reader :id, :config, :group, :pool_size, :pool_timeout
 
     def initialize(group, id, config)
       @id = id
       @config = config || {}
       @url = URI.parse(@config["url"].to_s)
       @group = group
-      @connection_monitor = Monitor.new
+      @pool_size = positive_integer_setting("pool_size", "PGBOUNCERHERO_POOL_SIZE", DEFAULT_POOL_SIZE)
+      @pool_timeout = positive_float_setting("pool_timeout", "PGBOUNCERHERO_POOL_TIMEOUT", DEFAULT_POOL_TIMEOUT)
+      @pool_monitor = Monitor.new
     end
 
     def name
@@ -19,14 +25,28 @@ module PgBouncerHero
     end
 
     def connection
-      @connection_monitor.synchronize do
-        disconnect_connection! if @connection && connection_invalid?(@connection)
-        @connection ||= connection_model.new(host, port, user, password, dbname).connection
+      proxy = connection_proxy
+      proxy if with_connection { true }
+    end
+
+    def with_connection
+      pool = connection_pool
+      pool.with do |managed_connection|
+        managed_connection.with_connection { |raw_connection| yield raw_connection }
       end
+    rescue ConnectionPool::TimeoutError => e
+      Rails.logger.error("[PGBouncerHero] #{name} connection pool timed out after #{pool_timeout}s: #{e.message}")
+      nil
     end
 
     def disconnect!
-      @connection_monitor.synchronize { disconnect_connection! }
+      pool = @pool_monitor.synchronize do
+        current_pool = @connection_pool
+        @connection_pool = nil
+        @connection_proxy = nil
+        current_pool
+      end
+      pool&.shutdown(&:disconnect!)
     end
 
     def host
@@ -52,23 +72,23 @@ module PgBouncerHero
     private
 
     def execute(command)
-      @connection_monitor.synchronize do
-        connection&.exec(command)
+      with_connection { |raw_connection| raw_connection.exec(command) }
+    end
+
+    def connection_pool
+      @pool_monitor.synchronize do
+        @connection_pool ||= ConnectionPool.new(size: pool_size, timeout: pool_timeout) { build_connection }
       end
     end
 
-    def disconnect_connection!
-      @connection&.finish unless @connection&.finished?
-    rescue PG::Error
-      nil
-    ensure
-      @connection = nil
+    def connection_proxy
+      @pool_monitor.synchronize do
+        @connection_proxy ||= ConnectionPool::Wrapper.new(pool: connection_pool)
+      end
     end
 
-    def connection_invalid?(connection)
-      connection.finished? || connection.status != PG::CONNECTION_OK
-    rescue PG::Error
-      true
+    def build_connection
+      connection_model.new(host, port, user, password, dbname)
     end
 
     def connection_model
@@ -79,6 +99,22 @@ module PgBouncerHero
           end
         end
       end
+    end
+
+    def positive_integer_setting(config_key, environment_key, default)
+      value = config.fetch(config_key, ENV.fetch(environment_key, default))
+      parsed = Integer(value)
+      raise ArgumentError, "#{config_key} must be greater than zero" unless parsed.positive?
+
+      parsed
+    end
+
+    def positive_float_setting(config_key, environment_key, default)
+      value = config.fetch(config_key, ENV.fetch(environment_key, default))
+      parsed = Float(value)
+      raise ArgumentError, "#{config_key} must be a finite number greater than zero" unless parsed.positive? && parsed.finite?
+
+      parsed
     end
   end
 end

--- a/pgbouncerhero.gemspec
+++ b/pgbouncerhero.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "turbo-rails", ">= 1.0", "< 3"
   spec.add_dependency "stimulus-rails", ">= 1.0", "< 2"
   spec.add_dependency "pg", ">= 1.2", "< 2"
+  spec.add_dependency "connection_pool", ">= 3.0", "< 4"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "tailwindcss-rails", "~> 4.0"

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -1,8 +1,111 @@
 require "test_helper"
 
 class ConnectionTest < Minitest::Test
+  class FakeRawConnection
+    attr_accessor :status
+    attr_reader :finish_calls, :queries
+
+    def initialize(status: PG::CONNECTION_OK, finished: false, error: nil)
+      @status = status
+      @finished = finished
+      @error = error
+      @finish_calls = 0
+      @queries = []
+    end
+
+    def finished?
+      @finished
+    end
+
+    def finish
+      @finish_calls += 1
+      @finished = true
+    end
+
+    def exec(query)
+      raise @error if @error
+
+      @queries << query
+      []
+    end
+  end
+
   def test_connection_returns_nil_on_failure
-    conn = PgBouncerHero::Connection.new("localhost", 99999, "nobody", "nopass", "noexist")
-    assert_nil conn.connection
+    connection = build_connection(PG::ConnectionBad.new("unavailable"))
+
+    assert_nil connection.connection
+  end
+
+  def test_connection_reuses_a_valid_connection
+    raw_connection = FakeRawConnection.new
+    connection = build_connection(raw_connection)
+
+    assert_same raw_connection, connection.connection
+    assert_same raw_connection, connection.connection
+  end
+
+  def test_connection_replaces_a_finished_connection
+    stale_connection = FakeRawConnection.new(finished: true)
+    replacement_connection = FakeRawConnection.new
+    connection = build_connection(stale_connection, replacement_connection)
+
+    assert_same stale_connection, connection.connection
+    assert_same replacement_connection, connection.connection
+  end
+
+  def test_connection_replaces_a_connection_with_a_bad_status
+    stale_connection = FakeRawConnection.new(status: PG::CONNECTION_BAD)
+    replacement_connection = FakeRawConnection.new
+    connection = build_connection(stale_connection, replacement_connection)
+
+    assert_same stale_connection, connection.connection
+    assert_same replacement_connection, connection.connection
+    assert_equal 1, stale_connection.finish_calls
+  end
+
+  def test_disconnect_closes_the_connection
+    raw_connection = FakeRawConnection.new
+    connection = build_connection(raw_connection)
+    connection.connection
+
+    connection.disconnect!
+
+    assert_predicate raw_connection, :finished?
+    assert_nil connection.instance_variable_get(:@connection)
+  end
+
+  def test_delegates_methods_to_the_raw_connection
+    raw_connection = FakeRawConnection.new
+    connection = build_connection(raw_connection)
+
+    connection.exec("SHOW stats")
+
+    assert_equal [ "SHOW stats" ], raw_connection.queries
+    assert_equal PG::CONNECTION_OK, connection.status
+  end
+
+  def test_discards_a_connection_after_a_pg_error
+    stale_connection = FakeRawConnection.new(error: PG::ConnectionBad.new("lost"))
+    replacement_connection = FakeRawConnection.new
+    connection = build_connection(stale_connection, replacement_connection)
+
+    assert_raises(PG::ConnectionBad) { connection.exec("SHOW stats") }
+    assert_predicate stale_connection, :finished?
+    assert_same replacement_connection, connection.connection
+  end
+
+  private
+
+  def build_connection(*connections)
+    remaining_connections = connections.dup
+    model = Class.new(PgBouncerHero::Connection) do
+      define_method(:connect) do
+        candidate = remaining_connections.shift
+        raise candidate if candidate.is_a?(Exception)
+
+        candidate
+      end
+    end
+    model.new("localhost", 6432, "user", "password", "pgbouncer")
   end
 end

--- a/test/database_test.rb
+++ b/test/database_test.rb
@@ -1,84 +1,74 @@
 require "test_helper"
 
 class DatabaseTest < Minitest::Test
-  FakeConnection = Struct.new(:status, :finished, :finish_calls, :queries) do
-    def initialize(status: PG::CONNECTION_OK, finished: false)
-      super(status, finished, 0, [])
+  class FakeConnection
+    attr_reader :finish_calls, :queries
+
+    def initialize(tracker: nil)
+      @tracker = tracker
+      @finish_calls = 0
+      @queries = []
+      @finished = false
+    end
+
+    def status
+      PG::CONNECTION_OK
     end
 
     def finished?
-      finished
+      @finished
     end
 
     def finish
-      self.finish_calls += 1
-      self.finished = true
+      @finish_calls += 1
+      @finished = true
     end
 
     def exec(query)
-      queries << query
+      @tracker&.enter
+      sleep 0.02 if @tracker
+      @queries << query
       []
+    ensure
+      @tracker&.leave
     end
   end
 
-  class ConcurrentConnection < FakeConnection
+  class ConcurrencyTracker
     attr_reader :max_active
 
     def initialize
-      super
       @active = 0
       @max_active = 0
-      @activity_lock = Mutex.new
+      @lock = Mutex.new
     end
 
-    def exec(query)
-      @activity_lock.synchronize do
+    def enter
+      @lock.synchronize do
         @active += 1
         @max_active = [ @max_active, @active ].max
       end
-      sleep 0.01
-      super
-    ensure
-      @activity_lock.synchronize { @active -= 1 }
+    end
+
+    def leave
+      @lock.synchronize { @active -= 1 }
     end
   end
 
   def setup
-    config = {
-      "test_group" => {
-        "primary" => {
-          "url" => "postgres://user:pass@localhost:6432/pgbouncer"
-        }
-      }
-    }
-    @group = PgBouncerHero::Group.new("test_group", config)
-    @database = @group.databases.first
+    @database = build_database
   end
 
-  def test_database_name
+  def test_database_attributes
     assert_equal "primary", @database.name
-  end
-
-  def test_database_host
     assert_equal "localhost", @database.host
-  end
-
-  def test_database_port
     assert_equal 6432, @database.port
-  end
-
-  def test_database_user
     assert_equal "user", @database.user
-  end
-
-  def test_database_dbname
     assert_equal "pgbouncer", @database.dbname
   end
 
   def test_database_with_nil_url
-    config = { "test_group" => { "primary" => {} } }
-    group = PgBouncerHero::Group.new("test_group", config)
-    database = group.databases.first
+    database = build_database({})
 
     assert_nil database.host
     assert_nil database.port
@@ -86,91 +76,168 @@ class DatabaseTest < Minitest::Test
   end
 
   def test_database_with_nil_config
-    config = { "test_group" => { "primary" => nil } }
-    group = PgBouncerHero::Group.new("test_group", config)
-    database = group.databases.first
+    database = build_database(nil)
 
     assert_nil database.host
     assert_nil database.connection
   end
 
   def test_database_with_empty_url
-    config = { "test_group" => { "primary" => { "url" => "" } } }
-    group = PgBouncerHero::Group.new("test_group", config)
-    database = group.databases.first
+    database = build_database("url" => "")
 
     assert_nil database.host
     assert_nil database.port
     assert_nil database.connection
   end
 
-  def test_connection_reuses_a_valid_connection
-    connection = FakeConnection.new
-    @database.instance_variable_set(:@connection, connection)
+  def test_pool_settings_use_database_config
+    database = build_database("pool_size" => 3, "pool_timeout" => 0.25)
 
-    assert_same connection, @database.connection
+    assert_equal 3, database.pool_size
+    assert_in_delta 0.25, database.pool_timeout
   end
 
-  def test_connection_replaces_a_connection_with_a_bad_status
-    stale_connection = FakeConnection.new(status: PG::CONNECTION_BAD)
-    replacement_connection = FakeConnection.new
-    @database.instance_variable_set(:@connection, stale_connection)
+  def test_pool_settings_must_be_positive
+    error = assert_raises(ArgumentError) { build_database("pool_size" => 0) }
 
-    stub_connection_model(replacement_connection)
-
-    assert_same replacement_connection, @database.connection
-    assert_predicate stale_connection, :finished?
-    assert_equal 1, stale_connection.finish_calls
+    assert_equal "pool_size must be greater than zero", error.message
   end
 
-  def test_connection_replaces_a_finished_connection
-    stale_connection = FakeConnection.new(finished: true)
-    replacement_connection = FakeConnection.new
-    @database.instance_variable_set(:@connection, stale_connection)
+  def test_pool_settings_use_environment_defaults
+    with_pool_environment("3", "0.25") do
+      database = build_database
 
-    stub_connection_model(replacement_connection)
-
-    assert_same replacement_connection, @database.connection
-    assert_equal 0, stale_connection.finish_calls
+      assert_equal 3, database.pool_size
+      assert_in_delta 0.25, database.pool_timeout
+    end
   end
 
-  def test_disconnect_closes_and_clears_the_connection
-    connection = FakeConnection.new
-    @database.instance_variable_set(:@connection, connection)
+  def test_database_pool_settings_override_the_environment
+    with_pool_environment("4", "0.5") do
+      database = build_database("pool_size" => 2, "pool_timeout" => 0.1)
 
-    @database.disconnect!
-
-    assert_predicate connection, :finished?
-    assert_nil @database.instance_variable_get(:@connection)
+      assert_equal 2, database.pool_size
+      assert_in_delta 0.1, database.pool_timeout
+    end
   end
 
-  def test_commands_execute_on_the_connection
-    connection = FakeConnection.new
-    @database.instance_variable_set(:@connection, connection)
+  def test_pool_timeout_must_be_finite
+    error = assert_raises(ArgumentError) { build_database("pool_timeout" => Float::INFINITY) }
 
-    @database.stats
-
-    assert_equal [ "SHOW stats" ], connection.queries
+    assert_equal "pool_timeout must be a finite number greater than zero", error.message
   end
 
-  def test_commands_are_serialized_per_database
-    connection = ConcurrentConnection.new
-    @database.instance_variable_set(:@connection, connection)
+  def test_connection_returns_a_connection_compatible_proxy
+    raw_connection = FakeConnection.new
+    stub_connection_model(@database) { raw_connection }
 
-    threads = 4.times.map { Thread.new { @database.stats } }
+    assert_equal PG::CONNECTION_OK, @database.connection.status
+  end
+
+  def test_with_connection_yields_a_raw_connection
+    raw_connection = FakeConnection.new
+    stub_connection_model(@database) { raw_connection }
+
+    yielded_connection = @database.with_connection { |connection| connection }
+
+    assert_same raw_connection, yielded_connection
+  end
+
+  def test_commands_reuse_idle_connections
+    connections = []
+    stub_connection_model(@database) { FakeConnection.new.tap { |connection| connections << connection } }
+
+    2.times { @database.stats }
+
+    assert_equal 1, connections.size
+    assert_equal [ "SHOW stats", "SHOW stats" ], connections.first.queries
+  end
+
+  def test_commands_run_concurrently_up_to_the_pool_size
+    tracker = ConcurrencyTracker.new
+    database = build_database("pool_size" => 2)
+    connections = []
+    stub_connection_model(database) do
+      FakeConnection.new(tracker: tracker).tap { |connection| connections << connection }
+    end
+
+    threads = 4.times.map { Thread.new { database.stats } }
     threads.each(&:join)
 
-    assert_equal 1, connection.max_active
-    assert_equal [ "SHOW stats" ] * 4, connection.queries
+    assert_equal 2, tracker.max_active
+    assert_equal 2, connections.size
+    assert_equal 4, connections.sum { |connection| connection.queries.size }
+  ensure
+    database&.disconnect!
+  end
+
+  def test_pool_timeout_returns_nil
+    database = build_database("pool_size" => 1, "pool_timeout" => 0.01)
+    stub_connection_model(database) { FakeConnection.new }
+    checked_out = Queue.new
+    release = Queue.new
+    holder = Thread.new do
+      database.with_connection do
+        checked_out << true
+        release.pop
+      end
+    end
+    checked_out.pop
+
+    assert_nil database.stats
+  ensure
+    release&.push(true)
+    holder&.join
+    database&.disconnect!
+  end
+
+  def test_disconnect_closes_every_initialized_connection
+    database = build_database("pool_size" => 2)
+    connections = []
+    stub_connection_model(database) { FakeConnection.new.tap { |connection| connections << connection } }
+    checked_out = Queue.new
+    release = Queue.new
+    holders = 2.times.map do
+      Thread.new do
+        database.with_connection do
+          checked_out << true
+          release.pop
+        end
+      end
+    end
+    2.times { checked_out.pop }
+    2.times { release << true }
+    holders.each(&:join)
+
+    database.disconnect!
+
+    assert_equal 2, connections.size
+    assert connections.all?(&:finished?)
   end
 
   private
 
-  def stub_connection_model(connection)
-    connection_model = Class.new do
-      define_method(:initialize) { |*| }
-      define_method(:connection) { connection }
+  def build_database(database_config = :default)
+    database_config = { "url" => "postgres://user:pass@localhost:6432/pgbouncer" } if database_config == :default
+    config = { "test_group" => { "primary" => database_config } }
+    PgBouncerHero::Group.new("test_group", config).databases.first
+  end
+
+  def stub_connection_model(database, &factory)
+    connection_model = Class.new(PgBouncerHero::Connection) do
+      define_method(:connect, &factory)
     end
-    @database.define_singleton_method(:connection_model) { connection_model }
+    database.define_singleton_method(:connection_model) { connection_model }
+  end
+
+  def with_pool_environment(size, timeout)
+    previous_size = ENV["PGBOUNCERHERO_POOL_SIZE"]
+    previous_timeout = ENV["PGBOUNCERHERO_POOL_TIMEOUT"]
+    ENV["PGBOUNCERHERO_POOL_SIZE"] = size
+    ENV["PGBOUNCERHERO_POOL_TIMEOUT"] = timeout
+    yield
+  ensure
+    ENV["PGBOUNCERHERO_POOL_SIZE"] = previous_size
+    ENV["PGBOUNCERHERO_POOL_TIMEOUT"] = previous_timeout
   end
 end

--- a/test/integration/pgbouncer_test.rb
+++ b/test/integration/pgbouncer_test.rb
@@ -9,7 +9,7 @@ class PgBouncerIntegrationTest < Minitest::Test
   def setup
     config = {
       "integration" => {
-        "primary" => { "url" => URL }
+        "primary" => { "url" => URL, "pool_size" => 1, "pool_timeout" => 0.1 }
       }
     }
     @database = PgBouncerHero::Group.new("integration", config).databases.first
@@ -20,7 +20,7 @@ class PgBouncerIntegrationTest < Minitest::Test
   end
 
   def test_connects_to_the_pgbouncer_admin_console
-    result = @database.connection.exec("SHOW VERSION")
+    result = @database.with_connection { |connection| connection.exec("SHOW VERSION") }
 
     assert_match(/\APgBouncer \d+\.\d+\.\d+/, result.first.fetch("version"))
     assert_equal PG::CONNECTION_OK, @database.connection.status
@@ -51,13 +51,42 @@ class PgBouncerIntegrationTest < Minitest::Test
   end
 
   def test_reconnects_after_the_connection_is_finished
-    original = @database.connection
+    original = @database.with_connection { |connection| connection }
     original.finish
 
-    replacement = @database.connection
+    replacement = @database.with_connection { |connection| connection }
 
     refute_same original, replacement
     assert_equal PG::CONNECTION_OK, replacement.status
+  end
+
+  def test_checks_out_multiple_real_connections_concurrently
+    config = {
+      "integration" => {
+        "pooled" => { "url" => URL, "pool_size" => 2, "pool_timeout" => 0.1 }
+      }
+    }
+    database = PgBouncerHero::Group.new("integration", config).databases.first
+    checked_out = Queue.new
+    release = Queue.new
+    threads = 2.times.map do
+      Thread.new do
+        database.with_connection do |connection|
+          checked_out << connection.object_id
+          release.pop
+        end
+      end
+    end
+
+    connection_ids = 2.times.map { checked_out.pop }
+    2.times { release << true }
+    threads.each(&:join)
+
+    assert_equal 2, connection_ids.uniq.size
+  ensure
+    2.times { release&.push(true) }
+    threads&.each(&:join)
+    database&.disconnect!
   end
 
   def test_reload_keeps_the_admin_console_available
@@ -70,7 +99,7 @@ class PgBouncerIntegrationTest < Minitest::Test
   def test_rejects_invalid_credentials
     invalid_url = URI(URL).dup
     invalid_url.password = "incorrect"
-    config = { "integration" => { "invalid" => { "url" => invalid_url.to_s } } }
+    config = { "integration" => { "invalid" => { "url" => invalid_url.to_s, "pool_size" => 1 } } }
     database = PgBouncerHero::Group.new("integration", config).databases.first
 
     assert_nil database.connection


### PR DESCRIPTION
## Summary

- add a bounded, lazy connection pool for each configured PgBouncer
- support global and per-database pool size and checkout timeout settings
- reconnect stale or failed connections and close every pooled connection on reset
- document explicit multi-command connection leases and preserve the existing connection proxy API
- expand unit and live PgBouncer coverage for pooling, concurrency, timeouts, and reconnection

## Test plan

- [x] `bundle exec rake`
- [x] `bundle exec appraisal rake test` (Rails 7.2, 8.0, and 8.1)
- [x] `bundle exec rake build`
- [x] `bundle exec rake test:integration` against the Docker Compose PgBouncer stack
- [x] `git diff --check`