### PR TITLE
Add safe PgBouncer admin controls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,13 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        pgbouncer: ["v1.23.1-p0", "v1.24.1-p0", "v1.25.2-p0"]
+    name: PgBouncer ${{ matrix.pgbouncer }}
+    env:
+      PGBOUNCER_INTEGRATION_IMAGE: edoburu/pgbouncer:${{ matrix.pgbouncer }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
@@ -55,14 +62,14 @@ jobs:
           ruby-version: "3.4"
           bundler-cache: true
       - name: Start PostgreSQL and PgBouncer
-        run: docker compose up --detach --wait --wait-timeout 60
+        run: docker compose -f docker-compose.yml -f docker-compose.integration.yml up --detach --wait --wait-timeout 60
       - name: Run PgBouncer integration tests
         run: bundle exec rake test:integration
         env:
           PGBOUNCERHERO_INTEGRATION_URL: postgres://pgbouncer:pgbouncer@127.0.0.1:6432/pgbouncer
       - name: Show container logs after a failure
         if: failure()
-        run: docker compose logs
+        run: docker compose -f docker-compose.yml -f docker-compose.integration.yml logs
       - name: Stop PostgreSQL and PgBouncer
         if: always()
-        run: docker compose down --volumes
+        run: docker compose -f docker-compose.yml -f docker-compose.integration.yml down --volumes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
 **New:**
+- Read-only mode for hiding and server-side blocking PgBouncer administrative commands
+- PgBouncer state visibility and Resume controls
+- Integration coverage across supported PgBouncer 1.23, 1.24, and 1.25 releases
 - Bounded, thread-safe connection pools per PgBouncer with configurable size and checkout timeout
 - Explicit `Database#with_connection` leases for running multiple commands on one connection
 - Real PgBouncer integration coverage for admin queries, summaries, reloads, authentication, and reconnection
@@ -10,6 +13,7 @@
 - Request-level engine coverage and gem-package validation in CI
 
 **Improved:**
+- Use `SHUTDOWN WAIT_FOR_CLIENTS` for graceful shutdowns initiated from the dashboard
 - Reconnect stale or failed pooled connections automatically and close every pool on reset
 - Pin PostgreSQL and PgBouncer development images and wait for container health before testing
 - Let Dependabot maintain Docker image versions alongside gems and GitHub Actions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ PgBouncerHero is a Ruby gem that ships as a **Rails Engine** providing a web das
 
 - Ruby >= 3.2
 - Rails >= 7.2
+- PgBouncer >= 1.23
 
 ## Commands
 
@@ -36,7 +37,7 @@ bundle exec rake test:integration # Run real PgBouncer tests after docker compos
 - `lib/pgbouncerhero/connection.rb` — Wraps `PG.connect` with configurable timeout (default 5s, override via `PGBOUNCERHERO_TIMEOUT`), validates connections before reuse, and reconnects after failures.
 - `lib/pgbouncerhero/database.rb` — Parses a PgBouncer URL and owns a bounded, lazy connection pool per PgBouncer. Pool size and checkout timeout default to 5 and are configurable globally or per database.
 - `lib/pgbouncerhero/group.rb` — Collection of Database instances.
-- `lib/pgbouncerhero/methods/basics.rb` — Mixin executing PgBouncer admin commands.
+- `lib/pgbouncerhero/methods/basics.rb` — Mixin executing PgBouncer monitoring and process-control commands, including safe shutdown modes.
 
 ### Frontend Stack
 
@@ -48,7 +49,7 @@ bundle exec rake test:integration # Run real PgBouncer tests after docker compos
 ### Controllers (`app/controllers/pg_bouncer_hero/`)
 
 - `HomeController` — `index` renders overview of all groups/databases as cards.
-- `DatabaseController` — Per-database actions: `summary` (Turbo Frame), `databases`, `stats`, `pools`, `clients`, `conf`, `reload`, `suspend`, `shutdown`.
+- `DatabaseController` — Per-database monitoring and administrative actions. Administrative POST actions are blocked when read-only mode is enabled.
 
 ### JavaScript (`app/javascript/pgbouncerhero/`)
 
@@ -62,6 +63,7 @@ Routes are nested under `/:group/:database/` with constraints validating against
 ### Authentication
 
 Optional HTTP Basic Auth via `PGBOUNCERHERO_USERNAME` / `PGBOUNCERHERO_PASSWORD` env vars (only active when password is set). Also supports Devise `authenticate` block mounting.
+Optional read-only mode via top-level `read_only: true` or `PGBOUNCERHERO_READ_ONLY=true` hides and rejects all process-control commands.
 
 ## Key Conventions
 
@@ -76,7 +78,7 @@ Optional HTTP Basic Auth via `PGBOUNCERHERO_USERNAME` / `PGBOUNCERHERO_PASSWORD`
 - `test/dummy/` — Minimal Rails app for integration testing.
 - `test/test_helper.rb` — Loads dummy app and minitest.
 - Unit tests cover: version, configuration loading, groups, pooled connection lifecycle and concurrency, helpers, routing, and engine rendering.
-- `test/integration/` exercises real PgBouncer admin queries, summaries, reloads, authentication, reconnection, and concurrent pooled checkouts against the Docker Compose stack.
+- `test/integration/` exercises real PgBouncer admin queries, summaries, process controls, authentication, reconnection, and concurrent pooled checkouts against PgBouncer 1.23, 1.24, and 1.25 in CI.
 - Appraisal tests against Rails 7.2, 8.0, and 8.1.
 - CI runs Ruby 3.2/3.3/3.4/4.0 x Rails 7.2/8.0/8.1.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A graphical user interface for your PgBouncers.
 
 - Ruby >= 3.2
 - Rails >= 7.2
+- PgBouncer >= 1.23
 - Propshaft (asset pipeline)
 - importmap-rails
 
@@ -78,6 +79,9 @@ pgbouncers:
       url: <%= ENV["PGBOUNCER_STAGING_PRIMARY_DATABASE_URL"] %>
     replica:
       url: <%= ENV["PGBOUNCER_STAGING_REPLICA_DATABASE_URL"] %>
+
+# Optional: allow monitoring while blocking all administrative commands
+read_only: true
 ```
 
 Environment-specific top-level keys are also supported. PgBouncerHero reads
@@ -117,6 +121,21 @@ end
 existing integrations. Connections are checked when borrowed, and stale or
 failed connections are discarded and recreated automatically.
 
+### Safe Administration
+
+The dashboard shows PgBouncer's current state and provides Reload, Suspend,
+Resume, and graceful shutdown controls. Dashboard shutdown uses
+`SHUTDOWN WAIT_FOR_CLIENTS`: PgBouncer stops accepting new clients and exits
+after existing clients disconnect. The Ruby API keeps `database.shutdown` as
+the immediate command for compatibility and also accepts `:immediate`,
+`:wait_for_clients`, or `:wait_for_servers`. State visibility requires
+PgBouncer 1.19 or newer; graceful shutdown modes require PgBouncer 1.23 or
+newer.
+
+Set `read_only: true` at the top level of `config/pgbouncerhero.yml`, or set
+`PGBOUNCERHERO_READ_ONLY=true`, to hide and server-side reject every
+administrative command. The environment variable takes precedence over YAML.
+
 ## Development
 
 Start PostgreSQL and PgBouncer with Docker:
@@ -146,6 +165,7 @@ bundle exec rake test:integration # real PgBouncer admin-console tests
 The integration task expects PostgreSQL and PgBouncer from the Compose stack.
 Override `PGBOUNCERHERO_INTEGRATION_URL` to test another PgBouncer instance.
 The default is `postgres://pgbouncer:pgbouncer@127.0.0.1:6432/pgbouncer`.
+CI runs this suite against PgBouncer 1.23, 1.24, and 1.25.
 
 Stop Docker when done:
 

--- a/app/controllers/pg_bouncer_hero/database_controller.rb
+++ b/app/controllers/pg_bouncer_hero/database_controller.rb
@@ -1,5 +1,7 @@
 module PgBouncerHero
   class DatabaseController < ApplicationController
+    before_action :ensure_writable!, only: %i[reload suspend resume shutdown]
+
     def summary
       if @database.connection
         @dbs = @database.summary
@@ -48,6 +50,14 @@ module PgBouncerHero
       end
     end
 
+    def state
+      if @database.connection
+        @state = @database.state
+      else
+        flash[:error] = "#{@database.name} does not look online."
+      end
+    end
+
     def reload
       execute_admin_command(:reload, "reloaded")
     end
@@ -56,15 +66,25 @@ module PgBouncerHero
       execute_admin_command(:suspend, "suspended")
     end
 
+    def resume
+      execute_admin_command(:resume, "resumed")
+    end
+
     def shutdown
-      execute_admin_command(:shutdown, "shut down")
+      execute_admin_command(:shutdown, "asked to shut down after its clients disconnect", :wait_for_clients)
     end
 
     private
 
-    def execute_admin_command(command, past_tense)
+    def ensure_writable!
+      return unless PgBouncerHero.read_only?
+
+      render plain: "PgBouncerHero is configured as read-only.", status: :forbidden
+    end
+
+    def execute_admin_command(command, past_tense, *arguments)
       if @database.connection
-        @database.public_send(command)
+        @database.public_send(command, *arguments)
         flash[:success] = "#{@database.name} has been #{past_tense}."
       else
         flash[:error] = "#{@database.name} does not look online."

--- a/app/views/pg_bouncer_hero/database/_menu.html.erb
+++ b/app/views/pg_bouncer_hero/database/_menu.html.erb
@@ -7,11 +7,17 @@
       <%= link_to "Pools", pools_path(database: database.name.parameterize), class: "px-3 py-1.5 text-sm rounded-md #{is_active('pools') ? 'bg-gray-900 text-white' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'}" %>
       <%= link_to "Clients", clients_path(database: database.name.parameterize), class: "px-3 py-1.5 text-sm rounded-md #{is_active('clients') ? 'bg-gray-900 text-white' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'}" %>
       <%= link_to "Configuration", conf_path(database: database.name.parameterize), class: "px-3 py-1.5 text-sm rounded-md #{is_active('conf') ? 'bg-gray-900 text-white' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'}" %>
+      <%= link_to "State", state_path(database: database.name.parameterize), class: "px-3 py-1.5 text-sm rounded-md #{is_active('state') ? 'bg-gray-900 text-white' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'}" %>
     </div>
     <div class="flex items-center gap-2">
-      <%= button_to "Reload", reload_path(database: database.name.parameterize), method: :post, class: "px-3 py-1.5 text-sm font-medium rounded-md border border-green-300 text-green-700 hover:bg-green-50", form: { data: { turbo_confirm: "Are you sure?" } } %>
-      <%= button_to "Suspend", suspend_path(database: database.name.parameterize), method: :post, class: "px-3 py-1.5 text-sm font-medium rounded-md border border-blue-300 text-blue-700 hover:bg-blue-50", form: { data: { turbo_confirm: "Are you sure?" } } %>
-      <%= button_to "Shutdown", shutdown_path(database: database.name.parameterize), method: :post, class: "px-3 py-1.5 text-sm font-medium rounded-md border border-red-300 text-red-700 hover:bg-red-50", form: { data: { turbo_confirm: "Are you sure?" } } %>
+      <% if PgBouncerHero.read_only? %>
+        <span class="inline-flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700 ring-1 ring-gray-300 ring-inset">Read-only</span>
+      <% else %>
+        <%= button_to "Reload", reload_path(database: database.name.parameterize), method: :post, class: "px-3 py-1.5 text-sm font-medium rounded-md border border-green-300 text-green-700 hover:bg-green-50", form: { data: { turbo_confirm: "Reload PgBouncer configuration?" } } %>
+        <%= button_to "Suspend", suspend_path(database: database.name.parameterize), method: :post, class: "px-3 py-1.5 text-sm font-medium rounded-md border border-blue-300 text-blue-700 hover:bg-blue-50", form: { data: { turbo_confirm: "Suspend all PgBouncer socket processing until Resume is selected?" } } %>
+        <%= button_to "Resume", resume_path(database: database.name.parameterize), method: :post, class: "px-3 py-1.5 text-sm font-medium rounded-md border border-green-300 text-green-700 hover:bg-green-50", form: { data: { turbo_confirm: "Resume PgBouncer socket processing?" } } %>
+        <%= button_to "Graceful shutdown", shutdown_path(database: database.name.parameterize), method: :post, class: "px-3 py-1.5 text-sm font-medium rounded-md border border-red-300 text-red-700 hover:bg-red-50", form: { data: { turbo_confirm: "Stop accepting new clients and shut down after existing clients disconnect?" } } %>
+      <% end %>
     </div>
   </div>
 </nav>

--- a/app/views/pg_bouncer_hero/database/_state.html.erb
+++ b/app/views/pg_bouncer_hero/database/_state.html.erb
@@ -1,0 +1,11 @@
+<div class="bg-white rounded-lg border border-gray-200 shadow-sm p-4">
+  <h4 class="text-base font-semibold text-gray-900 mb-3">State</h4>
+  <dl class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+    <% state.each do |row| %>
+      <div>
+        <dt class="text-xs font-medium text-gray-500 uppercase tracking-wider"><%= row["key"].titleize %></dt>
+        <dd class="mt-1 text-sm text-gray-900"><%= row["value"] %></dd>
+      </div>
+    <% end %>
+  </dl>
+</div>

--- a/app/views/pg_bouncer_hero/database/state.html.erb
+++ b/app/views/pg_bouncer_hero/database/state.html.erb
@@ -1,0 +1,4 @@
+<%= render partial: "menu", locals: {database: @database} %>
+<% if @state %>
+  <%= render partial: "state", locals: {state: @state} %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,8 +14,10 @@ PgBouncerHero::Engine.routes.draw do
       get :pools, controller: :database
       get :clients, controller: :database
       get :conf, controller: :database
+      get :state, controller: :database
       post :reload, controller: :database
       post :suspend, controller: :database
+      post :resume, controller: :database
       post :shutdown, controller: :database
     end
   end

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -1,0 +1,3 @@
+services:
+  pgbouncer:
+    image: ${PGBOUNCER_INTEGRATION_IMAGE}

--- a/lib/generators/pgbouncerhero/templates/config.yml
+++ b/lib/generators/pgbouncerhero/templates/config.yml
@@ -16,3 +16,6 @@ pgbouncers:
 
 # Time zone (defaults to app time zone)
 # time_zone: "Pacific Time (US & Canada)"
+
+# Hide and reject Reload, Suspend, Resume, and Shutdown commands
+# read_only: true

--- a/lib/pgbouncerhero.rb
+++ b/lib/pgbouncerhero.rb
@@ -17,6 +17,20 @@ require "pgbouncerhero/engine"
 module PgBouncerHero
   class ConfigurationError < StandardError; end
 
+  BOOLEAN_SETTINGS = {
+    true => true,
+    false => false,
+    "1" => true,
+    "0" => false,
+    "true" => true,
+    "false" => false,
+    "yes" => true,
+    "no" => false,
+    "on" => true,
+    "off" => false
+  }.freeze
+  private_constant :BOOLEAN_SETTINGS
+
   STATE_MONITOR = Monitor.new
   private_constant :STATE_MONITOR
 
@@ -61,6 +75,13 @@ module PgBouncerHero
           [ group_id.parameterize, PgBouncerHero::Group.new(group_id, config.fetch("pgbouncers")) ]
         end
       end
+    end
+
+    def read_only?
+      value = ENV.fetch("PGBOUNCERHERO_READ_ONLY") { config.fetch("read_only", false) }
+      BOOLEAN_SETTINGS.fetch(value.is_a?(String) ? value.downcase : value)
+    rescue KeyError
+      raise ConfigurationError, "read_only must be a boolean"
     end
 
     def disconnect!

--- a/lib/pgbouncerhero/methods/basics.rb
+++ b/lib/pgbouncerhero/methods/basics.rb
@@ -1,6 +1,13 @@
 module PgBouncerHero
   module Methods
     module Basics
+      SHUTDOWN_MODES = {
+        nil => "",
+        immediate: "",
+        wait_for_clients: " WAIT_FOR_CLIENTS",
+        wait_for_servers: " WAIT_FOR_SERVERS"
+      }.freeze
+
       def summary
         if connection
           l = lists
@@ -29,14 +36,23 @@ module PgBouncerHero
       def conf
         execute("SHOW config")
       end
+      def state
+        execute("SHOW state")
+      end
       def reload
         execute("RELOAD")
       end
       def suspend
         execute("SUSPEND")
       end
-      def shutdown
-        execute("SHUTDOWN")
+      def resume
+        execute("RESUME")
+      end
+      def shutdown(mode = nil)
+        suffix = SHUTDOWN_MODES.fetch(mode)
+        execute("SHUTDOWN#{suffix}")
+      rescue KeyError
+        raise ArgumentError, "unsupported shutdown mode: #{mode.inspect}"
       end
     end
   end

--- a/test/database_test.rb
+++ b/test/database_test.rb
@@ -153,6 +153,37 @@ class DatabaseTest < Minitest::Test
     assert_equal [ "SHOW stats", "SHOW stats" ], connections.first.queries
   end
 
+  def test_admin_commands_use_supported_pgbouncer_syntax
+    raw_connection = FakeConnection.new
+    stub_connection_model(@database) { raw_connection }
+
+    @database.state
+    @database.reload
+    @database.suspend
+    @database.resume
+    @database.shutdown
+    @database.shutdown(:immediate)
+    @database.shutdown(:wait_for_clients)
+    @database.shutdown(:wait_for_servers)
+
+    assert_equal [
+      "SHOW state",
+      "RELOAD",
+      "SUSPEND",
+      "RESUME",
+      "SHUTDOWN",
+      "SHUTDOWN",
+      "SHUTDOWN WAIT_FOR_CLIENTS",
+      "SHUTDOWN WAIT_FOR_SERVERS"
+    ], raw_connection.queries
+  end
+
+  def test_shutdown_rejects_unknown_modes
+    error = assert_raises(ArgumentError) { @database.shutdown(:eventually) }
+
+    assert_equal "unsupported shutdown mode: :eventually", error.message
+  end
+
   def test_commands_run_concurrently_up_to_the_pool_size
     tracker = ConcurrencyTracker.new
     database = build_database("pool_size" => 2)

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -29,6 +29,47 @@ class EngineTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_read_only_mode_hides_controls_and_blocks_admin_commands
+    with_config(<<~YAML) do
+      read_only: true
+      pgbouncers:
+        Operations:
+          Primary: {}
+    YAML
+      get "/pgbouncerhero/operations/primary/state"
+
+      assert_response :success
+      assert_select "span", "Read-only"
+      assert_select "form[action$='/reload']", count: 0
+      assert_select "form[action$='/suspend']", count: 0
+      assert_select "form[action$='/resume']", count: 0
+      assert_select "form[action$='/shutdown']", count: 0
+
+      authenticity_token = css_select("meta[name='csrf-token']").first["content"]
+      post "/pgbouncerhero/operations/primary/reload", params: { authenticity_token: authenticity_token }
+
+      assert_response :forbidden
+      assert_equal "PgBouncerHero is configured as read-only.", response.body
+    end
+  end
+
+  def test_writable_mode_renders_complete_admin_controls
+    with_config(<<~YAML) do
+      pgbouncers:
+        Operations:
+          Primary: {}
+    YAML
+      get "/pgbouncerhero/operations/primary/state"
+
+      assert_response :success
+      assert_select "form[action$='/reload']", count: 1
+      assert_select "form[action$='/suspend']", count: 1
+      assert_select "form[action$='/resume']", count: 1
+      assert_select "form[action$='/shutdown']", count: 1
+      assert_select "button", "Graceful shutdown"
+    end
+  end
+
   private
 
   def with_config(contents)

--- a/test/integration/pgbouncer_test.rb
+++ b/test/integration/pgbouncer_test.rb
@@ -33,12 +33,15 @@ class PgBouncerIntegrationTest < Minitest::Test
       lists: @database.lists,
       pools: @database.pools,
       clients: @database.clients,
-      config: @database.conf
+      config: @database.conf,
+      state: @database.state
     }
 
     results.each_value { |result| assert_instance_of PG::Result, result }
     assert_includes results.fetch(:databases).map { |row| row.fetch("name") }, "app"
     assert_includes results.fetch(:config).map { |row| row.fetch("key") }, "listen_port"
+    state = results.fetch(:state).to_h { |row| [ row.fetch("key"), row.fetch("value") ] }
+    assert_equal "yes", state.fetch("active")
   end
 
   def test_builds_a_summary_from_real_results
@@ -93,6 +96,22 @@ class PgBouncerIntegrationTest < Minitest::Test
     result = @database.reload
 
     assert_equal PG::PGRES_COMMAND_OK, result.result_status
+    assert_instance_of PG::Result, @database.stats
+  end
+
+  def test_suspends_and_resumes_pgbouncer_on_one_admin_connection
+    statuses = @database.with_connection do |connection|
+      suspended = false
+      suspend_result = connection.exec("SUSPEND")
+      suspended = true
+      resume_result = connection.exec("RESUME")
+      suspended = false
+      [ suspend_result.result_status, resume_result.result_status ]
+    ensure
+      connection.exec("RESUME") if suspended
+    end
+
+    assert_equal [ PG::PGRES_COMMAND_OK, PG::PGRES_COMMAND_OK ], statuses
     assert_instance_of PG::Result, @database.stats
   end
 

--- a/test/pgbouncerhero_test.rb
+++ b/test/pgbouncerhero_test.rb
@@ -48,6 +48,42 @@ class PgBouncerHeroTest < Minitest::Test
     end
   end
 
+  def test_read_only_mode_uses_configuration
+    with_config(<<~YAML) do
+      read_only: true
+      pgbouncers:
+        local:
+          primary: {}
+    YAML
+      assert_predicate PgBouncerHero, :read_only?
+    end
+  end
+
+  def test_read_only_environment_setting_overrides_configuration
+    with_config(<<~YAML) do
+      read_only: true
+      pgbouncers:
+        local:
+          primary: {}
+    YAML
+      ENV["PGBOUNCERHERO_READ_ONLY"] = "off"
+
+      refute_predicate PgBouncerHero, :read_only?
+    ensure
+      ENV.delete("PGBOUNCERHERO_READ_ONLY")
+    end
+  end
+
+  def test_read_only_mode_rejects_invalid_values
+    ENV["PGBOUNCERHERO_READ_ONLY"] = "sometimes"
+
+    error = assert_raises(PgBouncerHero::ConfigurationError) { PgBouncerHero.read_only? }
+
+    assert_equal "read_only must be a boolean", error.message
+  ensure
+    ENV.delete("PGBOUNCERHERO_READ_ONLY")
+  end
+
   def test_groups_returns_hash
     ENV["PGBOUNCERHERO_DATABASE_URL"] = "postgres://user:pass@localhost:6432/pgbouncer"
     PgBouncerHero.reset!


### PR DESCRIPTION
## Summary

- add server-enforced read-only mode with YAML and environment configuration
- expose PgBouncer state and add a Resume control
- make dashboard shutdown graceful with `SHUTDOWN WAIT_FOR_CLIENTS` while preserving the immediate Ruby API
- test real Suspend → Resume behavior across PgBouncer 1.23, 1.24, and 1.25
- document PgBouncer 1.23 as the supported compatibility floor

## Test plan

- [x] `bundle exec rake`
- [x] `bundle exec appraisal rake test` (Rails 7.2, 8.0, and 8.1)
- [x] `bundle exec rake build`
- [x] `bundle exec rake test:integration` against PgBouncer 1.23.1, 1.24.1, and 1.25.2
- [x] Docker Compose override validation
- [x] `git diff --check`