### PR TITLE
Add OIDC gem release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version already committed on master (for example, 3.1.0)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - name: Read gem version
+        id: gem
+        run: echo "version=$(ruby -Ilib -rpgbouncerhero/version -e 'puts PgBouncerHero::VERSION')" >> "$GITHUB_OUTPUT"
+      - name: Verify requested version
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
+          GEM_VERSION: ${{ steps.gem.outputs.version }}
+        run: |
+          if [ "$REQUESTED_VERSION" != "$GEM_VERSION" ]; then
+            echo "::error::Requested $REQUESTED_VERSION but master contains $GEM_VERSION"
+            exit 1
+          fi
+      - name: Verify release
+        run: bundle exec rake
+      - uses: rubygems/release-gem@7f9650160c1a4e7989fdc9855807bdbd421d8b6b # v1.4.1
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GEM_VERSION: ${{ steps.gem.outputs.version }}
+        run: gh release create "v${GEM_VERSION}" --verify-tag --generate-notes --title "${GEM_VERSION}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,11 @@ bundle exec appraisal rake test  # Run tests across Rails versions
 bundle exec rake test:integration # Run real PgBouncer tests after docker compose up -d --wait
 ```
 
+Releases run through `.github/workflows/release.yml` using RubyGems trusted
+publishing. The workflow is manually dispatched from `master` with the version
+already committed in `lib/pgbouncerhero/version.rb`; it verifies the suite,
+publishes the gem, pushes the tag, and creates the GitHub release.
+
 ## Architecture
 
 **Rails Engine** mounted into a host app via `mount PgBouncerHero::Engine, at: "pgbouncerhero"`. Uses `isolate_namespace PgBouncerHero`.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,17 @@ Stop Docker when done:
 docker compose down --volumes
 ```
 
+### Releasing
+
+Releases use RubyGems trusted publishing through GitHub Actions, with no stored
+RubyGems API key. Configure a trusted publisher for the `pgbouncerhero` gem on
+RubyGems.org with repository owner `kwent`, repository `pgbouncerhero`, workflow
+`release.yml`, and environment `release`. Then run the **Release** workflow on
+`master` and enter the version already committed in
+`lib/pgbouncerhero/version.rb`. The workflow verifies the version and test
+suite, publishes the gem with an OIDC credential, pushes the version tag, and
+creates the matching GitHub release.
+
 ## Contributing
 
 1. Fork it


### PR DESCRIPTION
## Summary

- publish gems with RubyGems trusted publishing and short-lived GitHub OIDC credentials
- require an explicit version input and verify it matches master before release
- run the full verification suite before publishing
- push the version tag and create a generated GitHub release
- document the one-time trusted-publisher configuration

## Security

- no long-lived RubyGems API key is stored in GitHub
- workflow-level permissions default to read-only
- only the release job receives `contents: write` and `id-token: write`
- all actions are pinned to immutable commits
- the release job only runs from `master` in the `release` environment

## Test plan

- [x] release workflow parses as valid YAML
- [x] `bundle exec rake`
- [x] `bundle exec rake build`
- [x] `git diff --check`