### PR TITLE
Use RubyGems OIDC role for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,13 @@ jobs:
           fi
       - name: Verify release
         run: bundle exec rake
+      - name: Configure RubyGems OIDC credentials
+        uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
+        with:
+          role-to-assume: ${{ secrets.RUBYGEMS_OIDC_ROLE }}
       - uses: rubygems/release-gem@7f9650160c1a4e7989fdc9855807bdbd421d8b6b # v1.4.1
+        with:
+          setup-trusted-publisher: false
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,10 +26,12 @@ bundle exec appraisal rake test  # Run tests across Rails versions
 bundle exec rake test:integration # Run real PgBouncer tests after docker compose up -d --wait
 ```
 
-Releases run through `.github/workflows/release.yml` using RubyGems trusted
-publishing. The workflow is manually dispatched from `master` with the version
-already committed in `lib/pgbouncerhero/version.rb`; it verifies the suite,
-publishes the gem, pushes the tag, and creates the GitHub release.
+Releases run through `.github/workflows/release.yml` using a scoped RubyGems
+OIDC API Key Role stored as the `RUBYGEMS_OIDC_ROLE` GitHub Actions secret. The
+workflow is manually dispatched from `master` with the version already
+committed in `lib/pgbouncerhero/version.rb`; it verifies the suite, publishes
+the gem with a short-lived credential, pushes the tag, and creates the GitHub
+release.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -175,14 +175,14 @@ docker compose down --volumes
 
 ### Releasing
 
-Releases use RubyGems trusted publishing through GitHub Actions, with no stored
-RubyGems API key. Configure a trusted publisher for the `pgbouncerhero` gem on
-RubyGems.org with repository owner `kwent`, repository `pgbouncerhero`, workflow
-`release.yml`, and environment `release`. Then run the **Release** workflow on
-`master` and enter the version already committed in
+Releases use a scoped RubyGems OIDC API Key Role through GitHub Actions, with no
+long-lived RubyGems API key. The role is restricted to the `pgbouncerhero` gem,
+the `kwent/pgbouncerhero` repository, and the `rubygems.org` audience. Store its
+role token in the `RUBYGEMS_OIDC_ROLE` GitHub Actions secret. Then run the
+**Release** workflow on `master` and enter the version already committed in
 `lib/pgbouncerhero/version.rb`. The workflow verifies the version and test
-suite, publishes the gem with an OIDC credential, pushes the version tag, and
-creates the matching GitHub release.
+suite, exchanges GitHub's OIDC identity for a short-lived credential, publishes
+the gem, pushes the version tag, and creates the matching GitHub release.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- exchange the configured RubyGems OIDC API Key Role before releasing
- source the role identifier from the encrypted `RUBYGEMS_OIDC_ROLE` Actions secret
- disable the release action's default Trusted Publisher lookup
- document the role-based OIDC release flow

## Test plan

- [x] release workflow parses as valid YAML
- [x] `bundle exec rake`
- [x] `bundle exec rake build`
- [x] `git diff --check`