### PR TITLE
Disable attestations for OIDC role releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
       - uses: rubygems/release-gem@7f9650160c1a4e7989fdc9855807bdbd421d8b6b # v1.4.1
         with:
           setup-trusted-publisher: false
+          attestations: false
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- disable Sigstore attestations when publishing through the RubyGems OIDC API Key Role
- retain short-lived OIDC credentials and the official release action

## Why
The 3.1.0 release run successfully assumed the configured OIDC role, but RubyGems rejected the upload because attestations require Trusted Publishing rather than an OIDC API Key Role.

## Verification
- `bundle exec rake`
- 51 tests, 117 assertions
- RuboCop and Herb clean