### PR TITLE
Add connection pressure diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+**New:**
+- Servers and Users monitoring views for PgBouncer connection and user limits
+- Waiting-client pressure indicators on overview cards from pool `cl_waiting` counts
+
 ## 3.1.0 - 2026-08-23
 
 **New:**

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ Set `read_only: true` at the top level of `config/pgbouncerhero.yml`, or set
 `PGBOUNCERHERO_READ_ONLY=true`, to hide and server-side reject every
 administrative command. The environment variable takes precedence over YAML.
 
+Monitoring views include Databases, Stats, Pools, Clients, Servers, Users,
+Configuration, and State. Overview cards also show a waiting-client indicator
+when any pool reports a nonzero `cl_waiting` count.
+
 ## Development
 
 Start PostgreSQL and PgBouncer with Docker:

--- a/app/controllers/pg_bouncer_hero/database_controller.rb
+++ b/app/controllers/pg_bouncer_hero/database_controller.rb
@@ -42,6 +42,22 @@ module PgBouncerHero
       end
     end
 
+    def servers
+      if @database.connection
+        @servers = @database.servers
+      else
+        flash[:error] = "#{@database.name} does not look online."
+      end
+    end
+
+    def users
+      if @database.connection
+        @users = @database.users
+      else
+        flash[:error] = "#{@database.name} does not look online."
+      end
+    end
+
     def conf
       if @database.connection
         @conf = @database.conf

--- a/app/views/pg_bouncer_hero/database/_menu.html.erb
+++ b/app/views/pg_bouncer_hero/database/_menu.html.erb
@@ -6,6 +6,8 @@
       <%= link_to "Stats", stats_path(database: database.name.parameterize), class: "px-3 py-1.5 text-sm rounded-md #{is_active('stats') ? 'bg-gray-900 text-white' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'}" %>
       <%= link_to "Pools", pools_path(database: database.name.parameterize), class: "px-3 py-1.5 text-sm rounded-md #{is_active('pools') ? 'bg-gray-900 text-white' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'}" %>
       <%= link_to "Clients", clients_path(database: database.name.parameterize), class: "px-3 py-1.5 text-sm rounded-md #{is_active('clients') ? 'bg-gray-900 text-white' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'}" %>
+      <%= link_to "Servers", servers_path(database: database.name.parameterize), class: "px-3 py-1.5 text-sm rounded-md #{is_active('servers') ? 'bg-gray-900 text-white' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'}" %>
+      <%= link_to "Users", users_path(database: database.name.parameterize), class: "px-3 py-1.5 text-sm rounded-md #{is_active('users') ? 'bg-gray-900 text-white' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'}" %>
       <%= link_to "Configuration", conf_path(database: database.name.parameterize), class: "px-3 py-1.5 text-sm rounded-md #{is_active('conf') ? 'bg-gray-900 text-white' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'}" %>
       <%= link_to "State", state_path(database: database.name.parameterize), class: "px-3 py-1.5 text-sm rounded-md #{is_active('state') ? 'bg-gray-900 text-white' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'}" %>
     </div>

--- a/app/views/pg_bouncer_hero/database/_servers.html.erb
+++ b/app/views/pg_bouncer_hero/database/_servers.html.erb
@@ -1,0 +1,30 @@
+<div class="bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden">
+  <div class="px-4 py-3 border-b border-gray-200">
+    <h4 class="text-base font-semibold text-gray-900">Servers</h4>
+  </div>
+  <% rows = servers.to_a %>
+  <% if rows.empty? %>
+    <p class="px-4 py-6 text-sm text-gray-500">No server connections.</p>
+  <% else %>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <% rows.first.keys.each do |key| %>
+              <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"><%= key.titleize %></th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          <% rows.each do |row| %>
+            <tr class="hover:bg-gray-50">
+              <% row.each_value do |value| %>
+                <td class="px-4 py-2 text-sm text-gray-700 whitespace-nowrap"><%= value %></td>
+              <% end %>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</div>

--- a/app/views/pg_bouncer_hero/database/_users.html.erb
+++ b/app/views/pg_bouncer_hero/database/_users.html.erb
@@ -1,0 +1,30 @@
+<div class="bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden">
+  <div class="px-4 py-3 border-b border-gray-200">
+    <h4 class="text-base font-semibold text-gray-900">Users</h4>
+  </div>
+  <% rows = users.to_a %>
+  <% if rows.empty? %>
+    <p class="px-4 py-6 text-sm text-gray-500">No configured users.</p>
+  <% else %>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <% rows.first.keys.each do |key| %>
+              <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"><%= key.titleize %></th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          <% rows.each do |row| %>
+            <tr class="hover:bg-gray-50">
+              <% row.each_value do |value| %>
+                <td class="px-4 py-2 text-sm text-gray-700 whitespace-nowrap"><%= value %></td>
+              <% end %>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</div>

--- a/app/views/pg_bouncer_hero/database/servers.html.erb
+++ b/app/views/pg_bouncer_hero/database/servers.html.erb
@@ -1,0 +1,4 @@
+<%= render partial: "menu", locals: {database: @database} %>
+<% if @servers %>
+  <%= render partial: "servers", locals: {database: @database, servers: @servers} %>
+<% end %>

--- a/app/views/pg_bouncer_hero/database/users.html.erb
+++ b/app/views/pg_bouncer_hero/database/users.html.erb
@@ -1,0 +1,4 @@
+<%= render partial: "menu", locals: {database: @database} %>
+<% if @users %>
+  <%= render partial: "users", locals: {database: @database, users: @users} %>
+<% end %>

--- a/app/views/pg_bouncer_hero/home/_card_content.html.erb
+++ b/app/views/pg_bouncer_hero/home/_card_content.html.erb
@@ -1,5 +1,8 @@
 <% if database.connection %>
   <% summary = database.summary %>
+  <% pools_details_row = summary.find { |row| row.key?(:pools_details) || row.key?("pools_details") } %>
+  <% pools_details = pools_details_row ? (pools_details_row[:pools_details] || pools_details_row["pools_details"] || []) : [] %>
+  <% waiting_clients = Array(pools_details).sum { |pool| pool["cl_waiting"].to_i } %>
   <div class="px-4 py-3 flex items-start gap-6">
     <div class="space-y-1 text-sm text-gray-700">
       <div>
@@ -13,6 +16,13 @@
       <div>
         <% number = summary.select { |row| row["list"] == "pools" }.first["items"].to_i - 1 %>
         <%= pluralize(number, "pool") %>
+      </div>
+      <div>
+        <% if waiting_clients.positive? %>
+          <span class="inline-flex items-center rounded-md bg-yellow-50 px-2 py-1 text-xs font-medium text-yellow-800 ring-1 ring-yellow-200 ring-inset"><%= pluralize(waiting_clients, "waiting client") %></span>
+        <% else %>
+          <span class="text-xs text-gray-400">No clients waiting</span>
+        <% end %>
       </div>
     </div>
     <div class="flex-1 space-y-2">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ PgBouncerHero::Engine.routes.draw do
       get :stats, controller: :database
       get :pools, controller: :database
       get :clients, controller: :database
+      get :servers, controller: :database
+      get :users, controller: :database
       get :conf, controller: :database
       get :state, controller: :database
       post :reload, controller: :database

--- a/lib/pgbouncerhero/methods/basics.rb
+++ b/lib/pgbouncerhero/methods/basics.rb
@@ -12,9 +12,12 @@ module PgBouncerHero
         if connection
           l = lists
           d = databases
+          p = pools
           l = l.as_json
           d = d.as_json.reject { |a| a["name"] == "pgbouncer" }
+          p = p.as_json
           l.push({ databases_details: d })
+          l.push({ pools_details: p })
           l
         end
       end
@@ -32,6 +35,12 @@ module PgBouncerHero
       end
       def clients
         execute("SHOW clients")
+      end
+      def servers
+        execute("SHOW servers")
+      end
+      def users
+        execute("SHOW users")
       end
       def conf
         execute("SHOW config")

--- a/test/database_test.rb
+++ b/test/database_test.rb
@@ -4,8 +4,9 @@ class DatabaseTest < Minitest::Test
   class FakeConnection
     attr_reader :finish_calls, :queries
 
-    def initialize(tracker: nil)
+    def initialize(tracker: nil, responses: {})
       @tracker = tracker
+      @responses = responses
       @finish_calls = 0
       @queries = []
       @finished = false
@@ -28,7 +29,7 @@ class DatabaseTest < Minitest::Test
       @tracker&.enter
       sleep 0.02 if @tracker
       @queries << query
-      []
+      @responses.fetch(query, [])
     ensure
       @tracker&.leave
     end
@@ -151,6 +152,41 @@ class DatabaseTest < Minitest::Test
 
     assert_equal 1, connections.size
     assert_equal [ "SHOW stats", "SHOW stats" ], connections.first.queries
+  end
+
+  def test_servers_and_users_use_the_same_idle_connection
+    connections = []
+    stub_connection_model(@database) { FakeConnection.new.tap { |connection| connections << connection } }
+
+    @database.servers
+    @database.users
+
+    assert_equal 1, connections.size
+    assert_equal [ "SHOW servers", "SHOW users" ], connections.first.queries
+  end
+
+  def test_summary_includes_database_and_pool_details
+    responses = {
+      "SHOW lists" => [
+        { "list" => "users", "items" => "1" },
+        { "list" => "databases", "items" => "2" },
+        { "list" => "pools", "items" => "1" }
+      ],
+      "SHOW databases" => [
+        { "name" => "app", "current_connections" => "1", "max_connections" => "10" },
+        { "name" => "pgbouncer", "current_connections" => "0", "max_connections" => "0" }
+      ],
+      "SHOW pools" => [ { "cl_waiting" => "2" } ]
+    }
+    raw_connection = FakeConnection.new(responses: responses)
+    stub_connection_model(@database) { raw_connection }
+
+    summary = @database.summary
+
+    assert_equal responses.fetch("SHOW lists"), summary.first(3)
+    assert_equal [ responses.fetch("SHOW databases").first ], summary.find { |row| row.key?(:databases_details) }.fetch(:databases_details)
+    assert_equal responses.fetch("SHOW pools"), summary.find { |row| row.key?(:pools_details) }.fetch(:pools_details)
+    assert_equal [ "SHOW lists", "SHOW databases", "SHOW pools" ], raw_connection.queries
   end
 
   def test_admin_commands_use_supported_pgbouncer_syntax

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -29,6 +29,53 @@ class EngineTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_servers_page_renders_empty_state_and_active_navigation
+    with_stubbed_database(:servers, []) do
+      get "/pgbouncerhero/operations/primary/servers"
+
+      assert_response :success
+      assert_select "a.bg-gray-900", text: "Servers"
+      assert_select "p", "No server connections."
+    end
+  end
+
+  def test_users_page_renders_empty_state_and_active_navigation
+    with_stubbed_database(:users, []) do
+      get "/pgbouncerhero/operations/primary/users"
+
+      assert_response :success
+      assert_select "a.bg-gray-900", text: "Users"
+      assert_select "p", "No configured users."
+    end
+  end
+
+  def test_overview_renders_no_clients_waiting_when_pool_pressure_is_zero
+    with_stubbed_database_methods(summary: overview_summary(0)) do
+      get "/pgbouncerhero/operations/primary/summary"
+
+      assert_response :success
+      assert_select "span", text: "No clients waiting", count: 1
+    end
+  end
+
+  def test_overview_pluralizes_one_waiting_client
+    with_stubbed_database_methods(summary: overview_summary(1)) do
+      get "/pgbouncerhero/operations/primary/summary"
+
+      assert_response :success
+      assert_select "span", text: "1 waiting client", count: 1
+    end
+  end
+
+  def test_overview_pluralizes_multiple_waiting_clients
+    with_stubbed_database_methods(summary: overview_summary(2)) do
+      get "/pgbouncerhero/operations/primary/summary"
+
+      assert_response :success
+      assert_select "span", text: "2 waiting clients", count: 1
+    end
+  end
+
   def test_read_only_mode_hides_controls_and_blocks_admin_commands
     with_config(<<~YAML) do
       read_only: true
@@ -83,5 +130,38 @@ class EngineTest < ActionDispatch::IntegrationTest
     end
   ensure
     PgBouncerHero.config_path = previous_path
+  end
+
+  def with_stubbed_database(method, result)
+    with_stubbed_database_methods(method => result) { yield }
+  end
+
+  def with_stubbed_database_methods(results)
+    with_config(<<~YAML) do
+      pgbouncers:
+        Operations:
+          Primary:
+            url: postgres://user:pass@localhost:6432/pgbouncer
+    YAML
+      database = PgBouncerHero.groups.fetch("operations").databases.first
+      database.define_singleton_method(:connection) { true }
+      results.each do |method, result|
+        database.define_singleton_method(method) { result }
+      end
+      yield
+    ensure
+      database&.singleton_class&.remove_method(:connection)
+      results&.each_key { |method| database.singleton_class.remove_method(method) }
+    end
+  end
+
+  def overview_summary(waiting_clients)
+    [
+      { "list" => "users", "items" => "1" },
+      { "list" => "databases", "items" => "2" },
+      { "list" => "pools", "items" => "1" },
+      { databases_details: [ { "name" => "app", "current_connections" => "0", "max_connections" => "10" } ] },
+      { pools_details: [ { "cl_waiting" => waiting_clients.to_s } ] }
+    ]
   end
 end

--- a/test/integration/pgbouncer_test.rb
+++ b/test/integration/pgbouncer_test.rb
@@ -33,6 +33,8 @@ class PgBouncerIntegrationTest < Minitest::Test
       lists: @database.lists,
       pools: @database.pools,
       clients: @database.clients,
+      servers: @database.servers,
+      users: @database.users,
       config: @database.conf,
       state: @database.state
     }
@@ -51,6 +53,10 @@ class PgBouncerIntegrationTest < Minitest::Test
     assert database_details
     assert_includes database_details.fetch(:databases_details).map { |row| row.fetch("name") }, "app"
     refute_includes database_details.fetch(:databases_details).map { |row| row.fetch("name") }, "pgbouncer"
+    pools_details = summary.find { |row| row.key?(:pools_details) }
+
+    assert pools_details
+    assert_respond_to pools_details.fetch(:pools_details), :each
   end
 
   def test_reconnects_after_the_connection_is_finished


### PR DESCRIPTION
## Summary
- add Servers and Users monitoring views backed by `SHOW SERVERS` and `SHOW USERS`
- surface waiting-client pressure from pool `cl_waiting` counts on overview cards
- handle empty diagnostic results and document the new monitoring surface

## Verification
- `bundle exec rake` — 58 tests, 139 assertions; RuboCop and Herb clean
- `bundle exec appraisal rake test` — Rails 7.2, 8.0, and 8.1 pass
- `bundle exec rake build` — gem package valid
- PgBouncer 1.23/1.24/1.25 integration verification delegated to this PR’s CI matrix because the local Colima runtime was unavailable