### PR TITLE
Add database maintenance controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **New:**
 - Servers and Users monitoring views for PgBouncer connection and user limits
 - Waiting-client pressure indicators on overview cards from pool `cl_waiting` counts
+- Database-scoped Pause, Reconnect, Wait close, and Resume maintenance controls
 
 ## 3.1.0 - 2026-08-23
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ Set `read_only: true` at the top level of `config/pgbouncerhero.yml`, or set
 `PGBOUNCERHERO_READ_ONLY=true`, to hide and server-side reject every
 administrative command. The environment variable takes precedence over YAML.
 
+The Databases view provides scoped Pause, Reconnect, Wait close, and Resume
+controls for planned maintenance and database failovers. Pause waits for that
+database's server connections to be released and makes new client queries wait;
+Reconnect replaces released server connections; Wait close confirms marked
+connections have drained; and Resume restores client processing. Database names
+are quoted before being sent to the PgBouncer admin console.
+
 Monitoring views include Databases, Stats, Pools, Clients, Servers, Users,
 Configuration, and State. Overview cards also show a waiting-client indicator
 when any pool reports a nonzero `cl_waiting` count.

--- a/app/controllers/pg_bouncer_hero/database_controller.rb
+++ b/app/controllers/pg_bouncer_hero/database_controller.rb
@@ -1,6 +1,9 @@
 module PgBouncerHero
   class DatabaseController < ApplicationController
-    before_action :ensure_writable!, only: %i[reload suspend resume shutdown]
+    DATABASE_ADMIN_ACTIONS = %i[pause_database reconnect_database wait_close_database resume_database].freeze
+
+    before_action :ensure_writable!, only: [ :reload, :suspend, :resume, :shutdown, *DATABASE_ADMIN_ACTIONS ]
+    before_action :set_target_database, only: DATABASE_ADMIN_ACTIONS
 
     def summary
       if @database.connection
@@ -86,6 +89,22 @@ module PgBouncerHero
       execute_admin_command(:resume, "resumed")
     end
 
+    def pause_database
+      execute_database_admin_command(:pause, "paused")
+    end
+
+    def reconnect_database
+      execute_database_admin_command(:reconnect, "asked to reconnect released server connections")
+    end
+
+    def wait_close_database
+      execute_database_admin_command(:wait_close, "confirmed all marked server connections closed")
+    end
+
+    def resume_database
+      execute_database_admin_command(:resume, "resumed")
+    end
+
     def shutdown
       execute_admin_command(:shutdown, "asked to shut down after its clients disconnect", :wait_for_clients)
     end
@@ -96,6 +115,13 @@ module PgBouncerHero
       return unless PgBouncerHero.read_only?
 
       render plain: "PgBouncerHero is configured as read-only.", status: :forbidden
+    end
+
+    def set_target_database
+      @target_database = params[:target_database].to_s
+      return if @target_database.present?
+
+      render plain: "A target database is required.", status: :bad_request
     end
 
     def execute_admin_command(command, past_tense, *arguments)
@@ -109,6 +135,19 @@ module PgBouncerHero
       flash[:error] = "#{@database.name}: #{e.message.strip}"
     ensure
       redirect_back fallback_location: root_path
+    end
+
+    def execute_database_admin_command(command, past_tense)
+      if @database.connection
+        @database.public_send(command, @target_database)
+        flash[:success] = "#{@target_database} on #{@database.name} has been #{past_tense}."
+      else
+        flash[:error] = "#{@database.name} does not look online."
+      end
+    rescue PG::Error => e
+      flash[:error] = "#{@database.name}: #{e.message.strip}"
+    ensure
+      redirect_back fallback_location: databases_path
     end
   end
 end

--- a/app/views/pg_bouncer_hero/database/_databases.html.erb
+++ b/app/views/pg_bouncer_hero/database/_databases.html.erb
@@ -9,6 +9,9 @@
           <% databases.first.keys.each do |key| %>
             <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"><%= key.titleize %></th>
           <% end %>
+          <% unless PgBouncerHero.read_only? %>
+            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Maintenance</th>
+          <% end %>
         </tr>
       </thead>
       <tbody class="bg-white divide-y divide-gray-200">
@@ -16,6 +19,19 @@
           <tr class="hover:bg-gray-50">
             <% row.each do |_k, v| %>
               <td class="px-4 py-2 text-sm text-gray-700 whitespace-nowrap"><%= v %></td>
+            <% end %>
+            <% unless PgBouncerHero.read_only? %>
+              <td class="px-4 py-2 whitespace-nowrap">
+                <% target_database = row["name"].to_s %>
+                <% unless target_database == "pgbouncer" %>
+                  <div class="flex items-center gap-2">
+                    <%= button_to "Pause", pause_database_path(database: database.name.parameterize), method: :post, params: { target_database: target_database }, class: "px-2 py-1 text-xs font-medium rounded-md border border-amber-300 text-amber-800 hover:bg-amber-50", form: { data: { turbo_confirm: "Pause #{target_database}? New client queries will wait until this database is resumed." } } %>
+                    <%= button_to "Reconnect", reconnect_database_path(database: database.name.parameterize), method: :post, params: { target_database: target_database }, class: "px-2 py-1 text-xs font-medium rounded-md border border-blue-300 text-blue-700 hover:bg-blue-50", form: { data: { turbo_confirm: "Reconnect released server connections for #{target_database}?" } } %>
+                    <%= button_to "Wait close", wait_close_database_path(database: database.name.parameterize), method: :post, params: { target_database: target_database }, class: "px-2 py-1 text-xs font-medium rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50", form: { data: { turbo_confirm: "Wait until all marked server connections for #{target_database} have closed?" } } %>
+                    <%= button_to "Resume", resume_database_path(database: database.name.parameterize), method: :post, params: { target_database: target_database }, class: "px-2 py-1 text-xs font-medium rounded-md border border-green-300 text-green-700 hover:bg-green-50", form: { data: { turbo_confirm: "Resume client processing for #{target_database}?" } } %>
+                  </div>
+                <% end %>
+              </td>
             <% end %>
           </tr>
         <% end %>

--- a/app/views/pg_bouncer_hero/database/_menu.html.erb
+++ b/app/views/pg_bouncer_hero/database/_menu.html.erb
@@ -17,7 +17,7 @@
       <% else %>
         <%= button_to "Reload", reload_path(database: database.name.parameterize), method: :post, class: "px-3 py-1.5 text-sm font-medium rounded-md border border-green-300 text-green-700 hover:bg-green-50", form: { data: { turbo_confirm: "Reload PgBouncer configuration?" } } %>
         <%= button_to "Suspend", suspend_path(database: database.name.parameterize), method: :post, class: "px-3 py-1.5 text-sm font-medium rounded-md border border-blue-300 text-blue-700 hover:bg-blue-50", form: { data: { turbo_confirm: "Suspend all PgBouncer socket processing until Resume is selected?" } } %>
-        <%= button_to "Resume", resume_path(database: database.name.parameterize), method: :post, class: "px-3 py-1.5 text-sm font-medium rounded-md border border-green-300 text-green-700 hover:bg-green-50", form: { data: { turbo_confirm: "Resume PgBouncer socket processing?" } } %>
+        <%= button_to "Resume all", resume_path(database: database.name.parameterize), method: :post, class: "px-3 py-1.5 text-sm font-medium rounded-md border border-green-300 text-green-700 hover:bg-green-50", form: { data: { turbo_confirm: "Resume all paused or suspended PgBouncer processing?" } } %>
         <%= button_to "Graceful shutdown", shutdown_path(database: database.name.parameterize), method: :post, class: "px-3 py-1.5 text-sm font-medium rounded-md border border-red-300 text-red-700 hover:bg-red-50", form: { data: { turbo_confirm: "Stop accepting new clients and shut down after existing clients disconnect?" } } %>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,10 @@ PgBouncerHero::Engine.routes.draw do
       post :reload, controller: :database
       post :suspend, controller: :database
       post :resume, controller: :database
+      post :pause_database, controller: :database
+      post :reconnect_database, controller: :database
+      post :wait_close_database, controller: :database
+      post :resume_database, controller: :database
       post :shutdown, controller: :database
     end
   end

--- a/lib/pgbouncerhero/methods/basics.rb
+++ b/lib/pgbouncerhero/methods/basics.rb
@@ -54,14 +54,34 @@ module PgBouncerHero
       def suspend
         execute("SUSPEND")
       end
-      def resume
-        execute("RESUME")
+      def pause(database_name)
+        execute_database_command("PAUSE", database_name)
+      end
+      def reconnect(database_name)
+        execute_database_command("RECONNECT", database_name)
+      end
+      def wait_close(database_name)
+        execute_database_command("WAIT_CLOSE", database_name)
+      end
+      def resume(database_name = nil)
+        return execute("RESUME") if database_name.nil?
+
+        execute_database_command("RESUME", database_name)
       end
       def shutdown(mode = nil)
         suffix = SHUTDOWN_MODES.fetch(mode)
         execute("SHUTDOWN#{suffix}")
       rescue KeyError
         raise ArgumentError, "unsupported shutdown mode: #{mode.inspect}"
+      end
+
+      private
+
+      def execute_database_command(command, database_name)
+        name = database_name.to_s
+        raise ArgumentError, "database name must not be empty" if name.empty?
+
+        execute("#{command} #{PG::Connection.quote_ident(name)}")
       end
     end
   end

--- a/test/database_test.rb
+++ b/test/database_test.rb
@@ -197,6 +197,10 @@ class DatabaseTest < Minitest::Test
     @database.reload
     @database.suspend
     @database.resume
+    @database.pause("app")
+    @database.reconnect("app")
+    @database.wait_close("app")
+    @database.resume("app")
     @database.shutdown
     @database.shutdown(:immediate)
     @database.shutdown(:wait_for_clients)
@@ -207,11 +211,34 @@ class DatabaseTest < Minitest::Test
       "RELOAD",
       "SUSPEND",
       "RESUME",
+      'PAUSE "app"',
+      'RECONNECT "app"',
+      'WAIT_CLOSE "app"',
+      'RESUME "app"',
       "SHUTDOWN",
       "SHUTDOWN",
       "SHUTDOWN WAIT_FOR_CLIENTS",
       "SHUTDOWN WAIT_FOR_SERVERS"
     ], raw_connection.queries
+  end
+
+  def test_database_admin_commands_quote_database_names
+    raw_connection = FakeConnection.new
+    stub_connection_model(@database) { raw_connection }
+
+    @database.pause('app"; SHUTDOWN; "')
+
+    assert_equal [ 'PAUSE "app""; SHUTDOWN; """' ], raw_connection.queries
+  end
+
+  def test_database_admin_commands_reject_empty_database_names
+    raw_connection = FakeConnection.new
+    stub_connection_model(@database) { raw_connection }
+
+    error = assert_raises(ArgumentError) { @database.reconnect(nil) }
+
+    assert_equal "database name must not be empty", error.message
+    assert_empty raw_connection.queries
   end
 
   def test_shutdown_rejects_unknown_modes

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -50,7 +50,7 @@ class EngineTest < ActionDispatch::IntegrationTest
   end
 
   def test_overview_renders_no_clients_waiting_when_pool_pressure_is_zero
-    with_stubbed_database_methods(summary: overview_summary(0)) do
+    with_stubbed_database_methods({ summary: overview_summary(0) }) do
       get "/pgbouncerhero/operations/primary/summary"
 
       assert_response :success
@@ -59,7 +59,7 @@ class EngineTest < ActionDispatch::IntegrationTest
   end
 
   def test_overview_pluralizes_one_waiting_client
-    with_stubbed_database_methods(summary: overview_summary(1)) do
+    with_stubbed_database_methods({ summary: overview_summary(1) }) do
       get "/pgbouncerhero/operations/primary/summary"
 
       assert_response :success
@@ -68,7 +68,7 @@ class EngineTest < ActionDispatch::IntegrationTest
   end
 
   def test_overview_pluralizes_multiple_waiting_clients
-    with_stubbed_database_methods(summary: overview_summary(2)) do
+    with_stubbed_database_methods({ summary: overview_summary(2) }) do
       get "/pgbouncerhero/operations/primary/summary"
 
       assert_response :success
@@ -100,6 +100,71 @@ class EngineTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_read_only_mode_hides_and_blocks_database_maintenance_controls
+    rows = [ { "name" => "app", "paused" => "0" }, { "name" => "pgbouncer", "paused" => "0" } ]
+    with_stubbed_database_methods({ databases: rows }, read_only: true) do
+      get "/pgbouncerhero/operations/primary/databases"
+
+      assert_response :success
+      assert_select "th", text: "Maintenance", count: 0
+      assert_select "form[action$='/pause_database']", count: 0
+      authenticity_token = css_select("meta[name='csrf-token']").first["content"]
+
+      post "/pgbouncerhero/operations/primary/pause_database",
+        params: { authenticity_token: authenticity_token, target_database: "app" }
+
+      assert_response :forbidden
+      assert_equal "PgBouncerHero is configured as read-only.", response.body
+    end
+  end
+
+  def test_database_page_renders_scoped_maintenance_controls
+    rows = [ { "name" => "app", "paused" => "0" }, { "name" => "pgbouncer", "paused" => "0" } ]
+    with_stubbed_database(:databases, rows) do
+      get "/pgbouncerhero/operations/primary/databases"
+
+      assert_response :success
+      assert_select "th", text: "Maintenance", count: 1
+      %w[pause_database reconnect_database wait_close_database resume_database].each do |action|
+        assert_select "form[action$='/#{action}']", count: 1 do
+          assert_select "input[name='target_database'][value='app']", count: 1
+        end
+      end
+    end
+  end
+
+  def test_database_maintenance_requires_a_target_database
+    with_stubbed_database_methods({}) do
+      get "/pgbouncerhero/operations/primary/state"
+      authenticity_token = css_select("meta[name='csrf-token']").first["content"]
+
+      post "/pgbouncerhero/operations/primary/pause_database", params: { authenticity_token: authenticity_token }
+
+      assert_response :bad_request
+      assert_equal "A target database is required.", response.body
+    end
+  end
+
+  def test_database_maintenance_routes_dispatch_scoped_commands
+    calls = []
+    methods = %i[pause reconnect wait_close resume].to_h do |method|
+      [ method, ->(target_database) { calls << [ method, target_database ] } ]
+    end
+    with_stubbed_database_methods(methods) do
+      get "/pgbouncerhero/operations/primary/state"
+      authenticity_token = css_select("meta[name='csrf-token']").first["content"]
+
+      %w[pause reconnect wait_close resume].each do |command|
+        post "/pgbouncerhero/operations/primary/#{command}_database",
+          params: { authenticity_token: authenticity_token, target_database: "app" }
+
+        assert_response :redirect
+      end
+    end
+
+    assert_equal %i[pause reconnect wait_close resume].map { |method| [ method, "app" ] }, calls
+  end
+
   def test_writable_mode_renders_complete_admin_controls
     with_config(<<~YAML) do
       pgbouncers:
@@ -113,6 +178,7 @@ class EngineTest < ActionDispatch::IntegrationTest
       assert_select "form[action$='/suspend']", count: 1
       assert_select "form[action$='/resume']", count: 1
       assert_select "form[action$='/shutdown']", count: 1
+      assert_select "button", "Resume all"
       assert_select "button", "Graceful shutdown"
     end
   end
@@ -133,11 +199,12 @@ class EngineTest < ActionDispatch::IntegrationTest
   end
 
   def with_stubbed_database(method, result)
-    with_stubbed_database_methods(method => result) { yield }
+    with_stubbed_database_methods({ method => result }) { yield }
   end
 
-  def with_stubbed_database_methods(results)
+  def with_stubbed_database_methods(results, read_only: false)
     with_config(<<~YAML) do
+      read_only: #{read_only}
       pgbouncers:
         Operations:
           Primary:
@@ -146,7 +213,7 @@ class EngineTest < ActionDispatch::IntegrationTest
       database = PgBouncerHero.groups.fetch("operations").databases.first
       database.define_singleton_method(:connection) { true }
       results.each do |method, result|
-        database.define_singleton_method(method) { result }
+        database.define_singleton_method(method) { |*arguments| result.respond_to?(:call) ? result.call(*arguments) : result }
       end
       yield
     ensure

--- a/test/integration/pgbouncer_test.rb
+++ b/test/integration/pgbouncer_test.rb
@@ -121,6 +121,26 @@ class PgBouncerIntegrationTest < Minitest::Test
     assert_instance_of PG::Result, @database.stats
   end
 
+  def test_runs_database_scoped_maintenance_commands
+    paused = false
+    pause_result = @database.pause("app")
+    paused = true
+    resume_result = @database.resume("app")
+    paused = false
+    reconnect_result = @database.reconnect("app")
+    wait_close_result = @database.wait_close("app")
+
+    assert_equal [
+      PG::PGRES_COMMAND_OK,
+      PG::PGRES_COMMAND_OK,
+      PG::PGRES_COMMAND_OK,
+      PG::PGRES_COMMAND_OK
+    ], [ pause_result, resume_result, reconnect_result, wait_close_result ].map(&:result_status)
+    assert_instance_of PG::Result, @database.stats
+  ensure
+    @database.resume("app") if paused
+  end
+
   def test_rejects_invalid_credentials
     invalid_url = URI(URL).dup
     invalid_url.password = "incorrect"


### PR DESCRIPTION
## Summary
- add database-scoped Pause, Reconnect, Wait close, and Resume controls
- quote PgBouncer database identifiers before issuing admin commands
- enforce read-only mode server-side and distinguish global Resume all
- document the maintenance workflow and extend unit, request, and integration coverage

## Verification
- `bundle exec rake` — 64 tests, 168 assertions; RuboCop and Herb clean
- `bundle exec appraisal rake test` — Rails 7.2, 8.0, and 8.1 pass
- `bundle exec rake build` — gem package valid
- `bundle exec rake test:integration` — 9 tests, 34 assertions on PgBouncer 1.23.1, 1.24.1, and 1.25.2