### PR TITLE
Add live refresh to monitoring views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Waiting-client pressure indicators on overview cards from pool `cl_waiting` counts
 - Database-scoped Pause, Reconnect, Wait close, and Resume maintenance controls
 
+**Improved:**
+- Refresh every monitoring view automatically, with manual refresh and background-tab pausing
+
 ## 3.1.0 - 2026-08-23
 
 **New:**

--- a/README.md
+++ b/README.md
@@ -145,7 +145,10 @@ are quoted before being sent to the PgBouncer admin console.
 
 Monitoring views include Databases, Stats, Pools, Clients, Servers, Users,
 Configuration, and State. Overview cards also show a waiting-client indicator
-when any pool reports a nonzero `cl_waiting` count.
+when any pool reports a nonzero `cl_waiting` count. Monitoring pages refresh
+automatically every 60 seconds and include a manual Refresh control. Automatic
+polling pauses while the browser tab is hidden and refreshes immediately when
+the tab becomes visible again.
 
 ## Development
 

--- a/app/helpers/pg_bouncer_hero/application_helper.rb
+++ b/app/helpers/pg_bouncer_hero/application_helper.rb
@@ -51,10 +51,10 @@ module PgBouncerHero
     private
 
     def monitoring_refresh_controls
-      content_tag(:div, class: "flex items-center justify-end gap-3 mb-3") do
+      content_tag(:div, class: "flex items-center justify-between gap-2 mb-3") do
         safe_join([
           content_tag(:span, "Updated just now", class: "text-xs text-gray-500", data: { polling_target: "status" }, aria: { live: "polite" }),
-          button_tag("Refresh", type: "button", class: "px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 text-gray-700 hover:bg-white", data: { action: "polling#refresh" })
+          button_tag("Refresh", type: "button", class: "px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50", data: { action: "polling#refresh" })
         ])
       end
     end

--- a/app/helpers/pg_bouncer_hero/application_helper.rb
+++ b/app/helpers/pg_bouncer_hero/application_helper.rb
@@ -31,5 +31,32 @@ module PgBouncerHero
         end
       }.compact.reverse.join(" ")
     end
+
+    def monitoring_panel(&block)
+      frame_id = "monitoring_#{params[:action]}"
+
+      content_tag(:div,
+        data: {
+          controller: "polling",
+          polling_interval_value: 60_000,
+          action: "turbo:frame-load->polling#refreshed"
+        }) do
+        safe_join([
+          monitoring_refresh_controls,
+          turbo_frame_tag(frame_id, data: { polling_refresh_url: request.path }, &block)
+        ])
+      end
+    end
+
+    private
+
+    def monitoring_refresh_controls
+      content_tag(:div, class: "flex items-center justify-end gap-3 mb-3") do
+        safe_join([
+          content_tag(:span, "Updated just now", class: "text-xs text-gray-500", data: { polling_target: "status" }, aria: { live: "polite" }),
+          button_tag("Refresh", type: "button", class: "px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 text-gray-700 hover:bg-white", data: { action: "polling#refresh" })
+        ])
+      end
+    end
   end
 end

--- a/app/javascript/pgbouncerhero/controllers/polling_controller.js
+++ b/app/javascript/pgbouncerhero/controllers/polling_controller.js
@@ -2,26 +2,70 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static values = { interval: { type: Number, default: 60000 } }
+  static targets = ["status"]
 
   connect() {
+    this.visibilityChanged = this.visibilityChanged.bind(this)
+    document.addEventListener("visibilitychange", this.visibilityChanged)
     this.startPolling()
   }
 
   disconnect() {
+    document.removeEventListener("visibilitychange", this.visibilityChanged)
     this.stopPolling()
   }
 
   startPolling() {
-    this.timer = setInterval(() => {
-      this.element.querySelectorAll("turbo-frame[src]").forEach(frame => {
-        frame.reload()
-      })
-    }, this.intervalValue)
+    this.stopPolling()
+    if (document.hidden) return
+
+    this.timer = setInterval(() => this.refresh(), this.intervalValue)
   }
 
   stopPolling() {
     if (this.timer) {
       clearInterval(this.timer)
+      this.timer = null
     }
+  }
+
+  refresh() {
+    if (document.hidden) return
+
+    let refreshing = false
+
+    this.element.querySelectorAll("turbo-frame").forEach(frame => {
+      if (frame.hasAttribute("busy")) return
+
+      if (frame.src) {
+        frame.reload()
+        refreshing = true
+      } else if (frame.dataset.pollingRefreshUrl) {
+        frame.src = frame.dataset.pollingRefreshUrl
+        refreshing = true
+      }
+    })
+
+    if (refreshing) this.updateStatus("Refreshing…")
+  }
+
+  refreshed() {
+    const time = new Intl.DateTimeFormat([], { timeStyle: "medium" }).format(new Date())
+    this.updateStatus(`Updated ${time}`)
+  }
+
+  visibilityChanged() {
+    if (document.hidden) {
+      this.stopPolling()
+    } else {
+      this.refresh()
+      this.startPolling()
+    }
+  }
+
+  updateStatus(message) {
+    this.statusTargets.forEach(status => {
+      status.textContent = message
+    })
   }
 }

--- a/app/views/pg_bouncer_hero/database/clients.html.erb
+++ b/app/views/pg_bouncer_hero/database/clients.html.erb
@@ -1,4 +1,6 @@
 <%= render partial: "menu", locals: {database: @database} %>
-<% if @clients %>
-  <%= render partial: "clients", locals: {database: @database, clients: @clients} %>
+<%= monitoring_panel do %>
+  <% if @clients %>
+    <%= render partial: "clients", locals: {database: @database, clients: @clients} %>
+  <% end %>
 <% end %>

--- a/app/views/pg_bouncer_hero/database/conf.html.erb
+++ b/app/views/pg_bouncer_hero/database/conf.html.erb
@@ -1,4 +1,6 @@
 <%= render partial: "menu", locals: {database: @database} %>
-<% if @conf %>
-  <%= render partial: "conf", locals: {database: @database, conf: @conf} %>
+<%= monitoring_panel do %>
+  <% if @conf %>
+    <%= render partial: "conf", locals: {database: @database, conf: @conf} %>
+  <% end %>
 <% end %>

--- a/app/views/pg_bouncer_hero/database/databases.html.erb
+++ b/app/views/pg_bouncer_hero/database/databases.html.erb
@@ -1,4 +1,6 @@
 <%= render partial: "menu", locals: {database: @database} %>
-<% if @dbs %>
-  <%= render partial: "databases", locals: {database: @database, databases: @dbs} %>
+<%= monitoring_panel do %>
+  <% if @dbs %>
+    <%= render partial: "databases", locals: {database: @database, databases: @dbs} %>
+  <% end %>
 <% end %>

--- a/app/views/pg_bouncer_hero/database/pools.html.erb
+++ b/app/views/pg_bouncer_hero/database/pools.html.erb
@@ -1,4 +1,6 @@
 <%= render partial: "menu", locals: {database: @database} %>
-<% if @pools %>
-  <%= render partial: "pools", locals: {database: @database, pools: @pools} %>
+<%= monitoring_panel do %>
+  <% if @pools %>
+    <%= render partial: "pools", locals: {database: @database, pools: @pools} %>
+  <% end %>
 <% end %>

--- a/app/views/pg_bouncer_hero/database/servers.html.erb
+++ b/app/views/pg_bouncer_hero/database/servers.html.erb
@@ -1,4 +1,6 @@
 <%= render partial: "menu", locals: {database: @database} %>
-<% if @servers %>
-  <%= render partial: "servers", locals: {database: @database, servers: @servers} %>
+<%= monitoring_panel do %>
+  <% if @servers %>
+    <%= render partial: "servers", locals: {database: @database, servers: @servers} %>
+  <% end %>
 <% end %>

--- a/app/views/pg_bouncer_hero/database/state.html.erb
+++ b/app/views/pg_bouncer_hero/database/state.html.erb
@@ -1,4 +1,6 @@
 <%= render partial: "menu", locals: {database: @database} %>
-<% if @state %>
-  <%= render partial: "state", locals: {state: @state} %>
+<%= monitoring_panel do %>
+  <% if @state %>
+    <%= render partial: "state", locals: {state: @state} %>
+  <% end %>
 <% end %>

--- a/app/views/pg_bouncer_hero/database/stats.html.erb
+++ b/app/views/pg_bouncer_hero/database/stats.html.erb
@@ -1,4 +1,6 @@
 <%= render partial: "menu", locals: {database: @database} %>
-<% if @stats %>
-  <%= render partial: "stats", locals: {database: @database, stats: @stats} %>
+<%= monitoring_panel do %>
+  <% if @stats %>
+    <%= render partial: "stats", locals: {database: @database, stats: @stats} %>
+  <% end %>
 <% end %>

--- a/app/views/pg_bouncer_hero/database/users.html.erb
+++ b/app/views/pg_bouncer_hero/database/users.html.erb
@@ -1,4 +1,6 @@
 <%= render partial: "menu", locals: {database: @database} %>
-<% if @users %>
-  <%= render partial: "users", locals: {database: @database, users: @users} %>
+<%= monitoring_panel do %>
+  <% if @users %>
+    <%= render partial: "users", locals: {database: @database, users: @users} %>
+  <% end %>
 <% end %>

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -49,6 +49,32 @@ class EngineTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_monitoring_pages_render_refreshable_turbo_frames
+    results = {
+      databases: [ { "name" => "app" } ],
+      stats: [ { "database" => "app" } ],
+      pools: [ { "database" => "app" } ],
+      clients: [ { "database" => "app" } ],
+      servers: [ { "database" => "app" } ],
+      users: [ { "name" => "app" } ],
+      conf: [ { "key" => "pool_mode", "value" => "transaction" } ],
+      state: [ { "key" => "active" } ]
+    }
+
+    with_stubbed_database_methods(results) do
+      results.each_key do |action|
+        get "/pgbouncerhero/operations/primary/#{action}"
+
+        assert_response :success
+        assert_select "div[data-controller='polling'][data-polling-interval-value='60000']", count: 1
+        assert_select "turbo-frame#monitoring_#{action}[data-polling-refresh-url='/pgbouncerhero/operations/primary/#{action}']", count: 1
+        assert_select "turbo-frame#monitoring_#{action}[src]", count: 0
+        assert_select "button[data-action='polling#refresh']", text: "Refresh", count: 1
+        assert_select "span[data-polling-target='status']", text: "Updated just now", count: 1
+      end
+    end
+  end
+
   def test_overview_renders_no_clients_waiting_when_pool_pressure_is_zero
     with_stubbed_database_methods({ summary: overview_summary(0) }) do
       get "/pgbouncerhero/operations/primary/summary"


### PR DESCRIPTION
## Summary

- refresh every PgBouncer monitoring view in place every 60 seconds
- add a manual refresh control and visible last-updated timestamp
- pause polling in hidden tabs, refresh on return, and avoid overlapping requests

## Verification

- `bundle exec rake`
- `bundle exec appraisal rake test`
- `bundle exec rake build`
- `node --check app/javascript/pgbouncerhero/controllers/polling_controller.js`