### PR TITLE
Support per-instance read-only policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Search monitoring tables, remember visible column choices, and keep identifier and maintenance columns visible while scrolling
 - Show only the administrative actions that apply to the current PgBouncer or database state
 - Sort monitoring results by any data column and reset saved column choices to their defaults
+- Configure read-only administration independently for each PgBouncer, with the environment variable retained as a global override
 
 ## 3.1.0 - 2026-08-23
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Routes are nested under `/:group/:database/` with constraints validating against
 ### Authentication
 
 Optional HTTP Basic Auth via `PGBOUNCERHERO_USERNAME` / `PGBOUNCERHERO_PASSWORD` env vars (only active when password is set). Also supports Devise `authenticate` block mounting.
-Optional read-only mode via top-level `read_only: true` or `PGBOUNCERHERO_READ_ONLY=true` hides and rejects all process-control commands.
+Optional read-only mode via top-level or per-PgBouncer `read_only: true` hides and rejects process-control commands. `PGBOUNCERHERO_READ_ONLY` is the highest-precedence global override.
 
 ## Key Conventions
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ pgbouncers:
       url: <%= ENV["PGBOUNCER_PRODUCTION_PRIMARY_DATABASE_URL"] %>
       pool_size: 5
       pool_timeout: 5
+      read_only: true
     replica:
       url: <%= ENV["PGBOUNCER_PRODUCTION_REPLICA_DATABASE_URL"] %>
   staging:
@@ -135,6 +136,10 @@ newer.
 Set `read_only: true` at the top level of `config/pgbouncerhero.yml`, or set
 `PGBOUNCERHERO_READ_ONLY=true`, to hide and server-side reject every
 administrative command. The environment variable takes precedence over YAML.
+An individual PgBouncer can set `read_only: true` or `false` alongside its URL
+to override the top-level YAML default. This allows production instances to be
+read-only while staging instances remain writable. The environment variable is
+still the highest-precedence global override.
 
 The Databases view provides scoped Pause, Reconnect, Wait close, and Resume
 controls for planned maintenance and database failovers. Pause waits for that

--- a/app/controllers/pg_bouncer_hero/database_controller.rb
+++ b/app/controllers/pg_bouncer_hero/database_controller.rb
@@ -120,7 +120,7 @@ module PgBouncerHero
     end
 
     def ensure_writable!
-      return unless PgBouncerHero.read_only?
+      return unless @database.read_only?
 
       render plain: "PgBouncerHero is configured as read-only.", status: :forbidden
     end

--- a/app/views/pg_bouncer_hero/database/_databases.html.erb
+++ b/app/views/pg_bouncer_hero/database/_databases.html.erb
@@ -10,7 +10,7 @@
           <% databases.first.keys.each_with_index do |key, index| %>
             <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider <%= "sticky left-0 z-10 bg-gray-50" if index.zero? %>" data-column-key="<%= key %>"><%= key.titleize %></th>
           <% end %>
-          <% unless PgBouncerHero.read_only? %>
+          <% unless database.read_only? %>
             <th class="sticky right-0 z-10 min-w-52 bg-gray-50 px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider" data-column-key="maintenance" data-column-locked="true">Maintenance</th>
           <% end %>
         </tr>
@@ -21,7 +21,7 @@
             <% row.each_value.with_index do |value, index| %>
               <td class="px-4 py-2 text-sm text-gray-700 whitespace-nowrap <%= "sticky left-0 bg-white group-hover:bg-gray-50" if index.zero? %>"><%= value %></td>
             <% end %>
-            <% unless PgBouncerHero.read_only? %>
+            <% unless database.read_only? %>
               <td class="sticky right-0 min-w-52 bg-white px-4 py-2 whitespace-nowrap group-hover:bg-gray-50">
                 <% target_database = row["name"].to_s %>
                 <% unless target_database == "pgbouncer" %>

--- a/app/views/pg_bouncer_hero/database/_menu.html.erb
+++ b/app/views/pg_bouncer_hero/database/_menu.html.erb
@@ -15,7 +15,7 @@
       <%= link_to "State", state_path(database: database.name.parameterize), class: "px-3 py-1.5 text-sm rounded-md #{is_active('state') ? 'bg-gray-900 text-white' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'}" %>
     </div>
     <div class="flex items-center gap-2">
-      <% if PgBouncerHero.read_only? %>
+      <% if database.read_only? %>
         <span class="inline-flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700 ring-1 ring-gray-300 ring-inset">Read-only</span>
       <% else %>
         <%= button_to "Reload", reload_path(database: database.name.parameterize), method: :post, class: "px-3 py-1.5 text-sm font-medium rounded-md border border-green-300 text-green-700 hover:bg-green-50", form: { data: { turbo_confirm: "Reload PgBouncer configuration?" } } %>

--- a/app/views/pg_bouncer_hero/home/_card.html.erb
+++ b/app/views/pg_bouncer_hero/home/_card.html.erb
@@ -5,6 +5,9 @@
         <div class="text-base font-bold text-gray-900"><%= database.name %></div>
         <div class="text-xs text-gray-500"><%= database.host %></div>
       </div>
+      <% if database.read_only? %>
+        <span class="inline-flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700 ring-1 ring-gray-300 ring-inset">Read-only</span>
+      <% end %>
     </div>
   <% end %>
   <turbo-frame id="card_<%= database.group.name.parameterize %>_<%= database.name.parameterize %>" src="<%= summary_path(group: database.group.name.parameterize, database: database.name.parameterize) %>" loading="lazy">

--- a/lib/generators/pgbouncerhero/templates/config.yml
+++ b/lib/generators/pgbouncerhero/templates/config.yml
@@ -5,6 +5,7 @@ pgbouncers:
       # url: <%%= ENV["PGBOUNCER_PRODUCTION_PRIMARY_DATABASE_URL"] %>
       # pool_size: 5
       # pool_timeout: 5
+      # read_only: true
     # Add more databases
     # replica:
     #   url: <%%= ENV["PGBOUNCER_PRODUCTION_REPLICA_DATABASE_URL"] %>
@@ -17,5 +18,6 @@ pgbouncers:
 # Time zone (defaults to app time zone)
 # time_zone: "Pacific Time (US & Canada)"
 
-# Hide and reject Reload, Suspend, Resume, and Shutdown commands
+# Hide and reject administrative commands for every PgBouncer unless an
+# individual PgBouncer sets read_only explicitly
 # read_only: true

--- a/lib/pgbouncerhero.rb
+++ b/lib/pgbouncerhero.rb
@@ -79,6 +79,17 @@ module PgBouncerHero
 
     def read_only?
       value = ENV.fetch("PGBOUNCERHERO_READ_ONLY") { config.fetch("read_only", false) }
+      parse_read_only(value)
+    end
+
+    def read_only_for?(database)
+      value = ENV.fetch("PGBOUNCERHERO_READ_ONLY") do
+        database.config.fetch("read_only") { config.fetch("read_only", false) }
+      end
+      parse_read_only(value)
+    end
+
+    def parse_read_only(value)
       BOOLEAN_SETTINGS.fetch(value.is_a?(String) ? value.downcase : value)
     rescue KeyError
       raise ConfigurationError, "read_only must be a boolean"
@@ -99,6 +110,8 @@ module PgBouncerHero
         @groups = nil
       end
     end
+
+    private :parse_read_only
 
     private
 

--- a/lib/pgbouncerhero/database.rb
+++ b/lib/pgbouncerhero/database.rb
@@ -65,6 +65,10 @@ module PgBouncerHero
       @url.password if @url
     end
 
+    def read_only?
+      PgBouncerHero.read_only_for?(self)
+    end
+
     def dbname
       @url.path[1..-1] if @url
     end

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -126,6 +126,39 @@ class EngineTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_database_read_only_policy_hides_controls_and_blocks_admin_commands
+    with_stubbed_database_methods({}, database_read_only: true) do
+      get "/pgbouncerhero"
+
+      assert_response :success
+      assert_select "span", text: "Read-only", count: 1
+
+      get "/pgbouncerhero/operations/primary/state"
+
+      assert_response :success
+      assert_select "span", "Read-only"
+      assert_select "form[action$='/reload']", count: 0
+      authenticity_token = css_select("meta[name='csrf-token']").first["content"]
+
+      post "/pgbouncerhero/operations/primary/reload", params: { authenticity_token: authenticity_token }
+
+      assert_response :forbidden
+      assert_equal "PgBouncerHero is configured as read-only.", response.body
+    end
+  end
+
+  def test_database_writable_policy_overrides_the_top_level_default
+    rows = [ { "name" => "app", "paused" => "0" }, { "name" => "pgbouncer", "paused" => "0" } ]
+    with_stubbed_database_methods({ databases: rows }, read_only: true, database_read_only: false) do
+      get "/pgbouncerhero/operations/primary/databases"
+
+      assert_response :success
+      assert_select "span", text: "Read-only", count: 0
+      assert_select "th", text: "Maintenance", count: 1
+      assert_select "form[action$='/pause_database']", count: 1
+    end
+  end
+
   def test_read_only_mode_hides_and_blocks_database_maintenance_controls
     rows = [ { "name" => "app", "paused" => "0" }, { "name" => "pgbouncer", "paused" => "0" } ]
     with_stubbed_database_methods({ databases: rows }, read_only: true) do
@@ -271,13 +304,15 @@ class EngineTest < ActionDispatch::IntegrationTest
     with_stubbed_database_methods({ method => result }) { yield }
   end
 
-  def with_stubbed_database_methods(results, read_only: false)
+  def with_stubbed_database_methods(results, read_only: false, database_read_only: nil)
+    database_setting = "read_only: #{database_read_only}" unless database_read_only.nil?
     with_config(<<~YAML) do
       read_only: #{read_only}
       pgbouncers:
         Operations:
           Primary:
             url: postgres://user:pass@localhost:6432/pgbouncer
+            #{database_setting}
     YAML
       database = PgBouncerHero.groups.fetch("operations").databases.first
       database.define_singleton_method(:connection) { true }

--- a/test/pgbouncerhero_test.rb
+++ b/test/pgbouncerhero_test.rb
@@ -74,6 +74,54 @@ class PgBouncerHeroTest < Minitest::Test
     end
   end
 
+  def test_per_database_read_only_setting_overrides_the_top_level_default
+    with_config(<<~YAML) do
+      read_only: true
+      pgbouncers:
+        local:
+          writable:
+            read_only: false
+          protected: {}
+    YAML
+      writable, protected = PgBouncerHero.groups.fetch("local").databases
+
+      refute_predicate writable, :read_only?
+      assert_predicate protected, :read_only?
+      assert_predicate PgBouncerHero, :read_only?
+    end
+  end
+
+  def test_read_only_environment_setting_overrides_a_database_setting
+    with_config(<<~YAML) do
+      read_only: false
+      pgbouncers:
+        local:
+          primary:
+            read_only: false
+    YAML
+      ENV["PGBOUNCERHERO_READ_ONLY"] = "on"
+
+      assert_predicate PgBouncerHero.groups.fetch("local").databases.first, :read_only?
+    ensure
+      ENV.delete("PGBOUNCERHERO_READ_ONLY")
+    end
+  end
+
+  def test_per_database_read_only_setting_rejects_invalid_values
+    with_config(<<~YAML) do
+      pgbouncers:
+        local:
+          primary:
+            read_only: sometimes
+    YAML
+      database = PgBouncerHero.groups.fetch("local").databases.first
+
+      error = assert_raises(PgBouncerHero::ConfigurationError) { database.read_only? }
+
+      assert_equal "read_only must be a boolean", error.message
+    end
+  end
+
   def test_read_only_mode_rejects_invalid_values
     ENV["PGBOUNCERHERO_READ_ONLY"] = "sometimes"
 


### PR DESCRIPTION
## Summary
- allow each configured PgBouncer to override the top-level read-only default
- retain `PGBOUNCERHERO_READ_ONLY` as the highest-precedence global override
- enforce the selected instance policy server-side and hide administrative controls
- show read-only status on overview cards and instance pages, and document the configuration precedence

## Testing
- `bundle exec rake`
- `bundle exec appraisal rake test`
- `bundle exec rake build`
- coverage for per-instance overrides, environment precedence, invalid values, hidden controls, overview badges, and forbidden administrative POSTs