### PR TITLE
Emit admin command audit events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Show only the administrative actions that apply to the current PgBouncer or database state
 - Sort monitoring results by any data column and reset saved column choices to their defaults
 - Configure read-only administration independently for each PgBouncer, with the environment variable retained as a global override
+- Emit structured Active Support notifications for successful, unavailable, failed, and policy-denied administrative commands
 
 ## 3.1.0 - 2026-08-23
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ release.
 - `lib/pgbouncerhero/database.rb` — Parses a PgBouncer URL and owns a bounded, lazy connection pool per PgBouncer. Pool size and checkout timeout default to 5 and are configurable globally or per database.
 - `lib/pgbouncerhero/group.rb` — Collection of Database instances.
 - `lib/pgbouncerhero/methods/basics.rb` — Mixin executing PgBouncer monitoring and process-control commands, including safe shutdown modes.
+  Administrative commands emit structured `admin_command.pgbouncerhero` Active Support notifications for host-app auditing.
 
 ### Frontend Stack
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,21 @@ to override the top-level YAML default. This allows production instances to be
 read-only while staging instances remain writable. The environment variable is
 still the highest-precedence global override.
 
+Every administrative command emits an `admin_command.pgbouncerhero`
+`ActiveSupport::Notifications` event, including commands called through the
+Ruby API and dashboard attempts rejected by read-only policy. The payload
+contains `group`, `database`, `action`, `target_database`, and `outcome`; a
+shutdown also includes `mode`, and failed commands include `error_class` without
+exposing credentials or database error messages. Notification events provide
+their standard duration measurement to subscribers:
+
+```ruby
+ActiveSupport::Notifications.subscribe("admin_command.pgbouncerhero") do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+  Rails.logger.info(event.payload.merge(duration_ms: event.duration).to_json)
+end
+```
+
 The Databases view provides scoped Pause, Reconnect, Wait close, and Resume
 controls for planned maintenance and database failovers. Pause waits for that
 database's server connections to be released and makes new client queries wait;

--- a/app/controllers/pg_bouncer_hero/database_controller.rb
+++ b/app/controllers/pg_bouncer_hero/database_controller.rb
@@ -122,6 +122,14 @@ module PgBouncerHero
     def ensure_writable!
       return unless @database.read_only?
 
+      ActiveSupport::Notifications.instrument(
+        PgBouncerHero::ADMIN_COMMAND_EVENT,
+        group: @database.group.name,
+        database: @database.name,
+        action: action_name.delete_suffix("_database").to_sym,
+        target_database: params[:target_database].presence,
+        outcome: :denied
+      )
       render plain: "PgBouncerHero is configured as read-only.", status: :forbidden
     end
 
@@ -133,8 +141,7 @@ module PgBouncerHero
     end
 
     def execute_admin_command(command, past_tense, *arguments)
-      if @database.connection
-        @database.public_send(command, *arguments)
+      if @database.public_send(command, *arguments)
         flash[:success] = "#{@database.name} has been #{past_tense}."
       else
         flash[:error] = "#{@database.name} does not look online."
@@ -146,8 +153,7 @@ module PgBouncerHero
     end
 
     def execute_database_admin_command(command, past_tense)
-      if @database.connection
-        @database.public_send(command, @target_database)
+      if @database.public_send(command, @target_database)
         flash[:success] = "#{@target_database} on #{@database.name} has been #{past_tense}."
       else
         flash[:error] = "#{@database.name} does not look online."

--- a/lib/pgbouncerhero.rb
+++ b/lib/pgbouncerhero.rb
@@ -3,6 +3,7 @@ require "monitor"
 require "pathname"
 require "yaml"
 require "rails"
+require "active_support/notifications"
 require "pg"
 require "importmap-rails"
 require "turbo-rails"
@@ -15,6 +16,8 @@ require "pgbouncerhero/group"
 require "pgbouncerhero/engine"
 
 module PgBouncerHero
+  ADMIN_COMMAND_EVENT = "admin_command.pgbouncerhero"
+
   class ConfigurationError < StandardError; end
 
   BOOLEAN_SETTINGS = {

--- a/lib/pgbouncerhero/methods/basics.rb
+++ b/lib/pgbouncerhero/methods/basics.rb
@@ -49,39 +49,70 @@ module PgBouncerHero
         execute("SHOW state")
       end
       def reload
-        execute("RELOAD")
+        instrument_admin_command(:reload) { execute("RELOAD") }
       end
       def suspend
-        execute("SUSPEND")
+        instrument_admin_command(:suspend) { execute("SUSPEND") }
       end
       def pause(database_name)
-        execute_database_command("PAUSE", database_name)
+        execute_database_command(:pause, "PAUSE", database_name)
       end
       def reconnect(database_name)
-        execute_database_command("RECONNECT", database_name)
+        execute_database_command(:reconnect, "RECONNECT", database_name)
       end
       def wait_close(database_name)
-        execute_database_command("WAIT_CLOSE", database_name)
+        execute_database_command(:wait_close, "WAIT_CLOSE", database_name)
       end
       def resume(database_name = nil)
-        return execute("RESUME") if database_name.nil?
+        return instrument_admin_command(:resume) { execute("RESUME") } if database_name.nil?
 
-        execute_database_command("RESUME", database_name)
+        execute_database_command(:resume, "RESUME", database_name)
       end
       def shutdown(mode = nil)
-        suffix = SHUTDOWN_MODES.fetch(mode)
-        execute("SHUTDOWN#{suffix}")
-      rescue KeyError
-        raise ArgumentError, "unsupported shutdown mode: #{mode.inspect}"
+        instrument_admin_command(:shutdown, mode: mode || :immediate) do
+          suffix = SHUTDOWN_MODES.fetch(mode)
+          execute("SHUTDOWN#{suffix}")
+        rescue KeyError
+          raise ArgumentError, "unsupported shutdown mode: #{mode.inspect}"
+        end
       end
 
       private
 
-      def execute_database_command(command, database_name)
+      def execute_database_command(action, command, database_name)
         name = database_name.to_s
-        raise ArgumentError, "database name must not be empty" if name.empty?
+        instrument_admin_command(action, target_database: name) do
+          raise ArgumentError, "database name must not be empty" if name.empty?
 
-        execute("#{command} #{PG::Connection.quote_ident(name)}")
+          execute("#{command} #{PG::Connection.quote_ident(name)}")
+        end
+      end
+
+      def instrument_admin_command(action, target_database: nil, **attributes)
+        payload = {
+          group: group.name,
+          database: name,
+          action: action,
+          target_database: target_database,
+          **attributes
+        }
+
+        error = nil
+        result = ActiveSupport::Notifications.instrument(PgBouncerHero::ADMIN_COMMAND_EVENT, payload) do
+          begin
+            command_result = yield
+            payload[:outcome] = command_result.nil? ? :unavailable : :success
+            command_result
+          rescue StandardError => command_error
+            error = command_error
+            payload[:outcome] = :error
+            payload[:error_class] = command_error.class.name
+            nil
+          end
+        end
+        raise error if error
+
+        result
       end
     end
   end

--- a/test/database_test.rb
+++ b/test/database_test.rb
@@ -231,14 +231,73 @@ class DatabaseTest < Minitest::Test
     assert_equal [ 'PAUSE "app""; SHUTDOWN; """' ], raw_connection.queries
   end
 
+  def test_admin_commands_emit_successful_audit_events
+    raw_connection = FakeConnection.new
+    stub_connection_model(@database) { raw_connection }
+
+    events = capture_admin_command_events { @database.pause("app") }
+    event = events.fetch(0)
+
+    assert_equal 1, events.size
+    assert_equal "test_group", event.payload.fetch(:group)
+    assert_equal "primary", event.payload.fetch(:database)
+    assert_equal :pause, event.payload.fetch(:action)
+    assert_equal "app", event.payload.fetch(:target_database)
+    assert_equal :success, event.payload.fetch(:outcome)
+    assert_operator event.duration, :>=, 0
+    refute event.payload.key?(:error_class)
+  end
+
+  def test_unavailable_admin_commands_emit_audit_events
+    database = build_database({})
+
+    events = capture_admin_command_events { assert_nil database.reload }
+
+    assert_equal :reload, events.fetch(0).payload.fetch(:action)
+    assert_equal :unavailable, events.fetch(0).payload.fetch(:outcome)
+  end
+
+  def test_failed_admin_commands_emit_error_classes_without_messages
+    @database.define_singleton_method(:execute) { |_command| raise PG::ConnectionBad, "private database detail" }
+
+    events = capture_admin_command_events do
+      assert_raises(PG::ConnectionBad) { @database.reload }
+    end
+    payload = events.fetch(0).payload
+
+    assert_equal :error, payload.fetch(:outcome)
+    assert_equal "PG::ConnectionBad", payload.fetch(:error_class)
+    refute_includes payload.values, "private database detail"
+    refute payload.key?(:exception)
+    refute payload.key?(:exception_object)
+  end
+
+  def test_shutdown_audit_events_include_the_mode
+    raw_connection = FakeConnection.new
+    stub_connection_model(@database) { raw_connection }
+
+    events = capture_admin_command_events { @database.shutdown(:wait_for_clients) }
+
+    assert_equal :shutdown, events.fetch(0).payload.fetch(:action)
+    assert_equal :wait_for_clients, events.fetch(0).payload.fetch(:mode)
+    assert_equal :success, events.fetch(0).payload.fetch(:outcome)
+  end
+
   def test_database_admin_commands_reject_empty_database_names
     raw_connection = FakeConnection.new
     stub_connection_model(@database) { raw_connection }
 
-    error = assert_raises(ArgumentError) { @database.reconnect(nil) }
+    events = capture_admin_command_events do
+      error = assert_raises(ArgumentError) { @database.reconnect(nil) }
 
-    assert_equal "database name must not be empty", error.message
+      assert_equal "database name must not be empty", error.message
+    end
+
     assert_empty raw_connection.queries
+    assert_equal :reconnect, events.fetch(0).payload.fetch(:action)
+    assert_equal "", events.fetch(0).payload.fetch(:target_database)
+    assert_equal :error, events.fetch(0).payload.fetch(:outcome)
+    assert_equal "ArgumentError", events.fetch(0).payload.fetch(:error_class)
   end
 
   def test_shutdown_rejects_unknown_modes

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -119,10 +119,15 @@ class EngineTest < ActionDispatch::IntegrationTest
       assert_select "form[action$='/shutdown']", count: 0
 
       authenticity_token = css_select("meta[name='csrf-token']").first["content"]
-      post "/pgbouncerhero/operations/primary/reload", params: { authenticity_token: authenticity_token }
+      events = capture_admin_command_events do
+        post "/pgbouncerhero/operations/primary/reload", params: { authenticity_token: authenticity_token }
+      end
 
       assert_response :forbidden
       assert_equal "PgBouncerHero is configured as read-only.", response.body
+      assert_equal :reload, events.fetch(0).payload.fetch(:action)
+      assert_equal :denied, events.fetch(0).payload.fetch(:outcome)
+      assert_nil events.fetch(0).payload.fetch(:target_database)
     end
   end
 
@@ -159,6 +164,25 @@ class EngineTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_unavailable_dashboard_admin_commands_emit_audit_events
+    with_config(<<~YAML) do
+      pgbouncers:
+        Operations:
+          Primary: {}
+    YAML
+      get "/pgbouncerhero/operations/primary/state"
+      authenticity_token = css_select("meta[name='csrf-token']").first["content"]
+
+      events = capture_admin_command_events do
+        post "/pgbouncerhero/operations/primary/reload", params: { authenticity_token: authenticity_token }
+      end
+
+      assert_response :redirect
+      assert_equal :reload, events.fetch(0).payload.fetch(:action)
+      assert_equal :unavailable, events.fetch(0).payload.fetch(:outcome)
+    end
+  end
+
   def test_read_only_mode_hides_and_blocks_database_maintenance_controls
     rows = [ { "name" => "app", "paused" => "0" }, { "name" => "pgbouncer", "paused" => "0" } ]
     with_stubbed_database_methods({ databases: rows }, read_only: true) do
@@ -169,11 +193,16 @@ class EngineTest < ActionDispatch::IntegrationTest
       assert_select "form[action$='/pause_database']", count: 0
       authenticity_token = css_select("meta[name='csrf-token']").first["content"]
 
-      post "/pgbouncerhero/operations/primary/pause_database",
-        params: { authenticity_token: authenticity_token, target_database: "app" }
+      events = capture_admin_command_events do
+        post "/pgbouncerhero/operations/primary/pause_database",
+          params: { authenticity_token: authenticity_token, target_database: "app" }
+      end
 
       assert_response :forbidden
       assert_equal "PgBouncerHero is configured as read-only.", response.body
+      assert_equal :pause, events.fetch(0).payload.fetch(:action)
+      assert_equal "app", events.fetch(0).payload.fetch(:target_database)
+      assert_equal :denied, events.fetch(0).payload.fetch(:outcome)
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,3 +3,19 @@ ENV["RAILS_ENV"] = "test"
 require_relative "dummy/config/environment"
 require "rails/test_help"
 require "minitest/autorun"
+
+module AdminCommandEventTestHelper
+  def capture_admin_command_events
+    events = []
+    subscriber = ActiveSupport::Notifications.subscribe(PgBouncerHero::ADMIN_COMMAND_EVENT) do |*arguments|
+      events << ActiveSupport::Notifications::Event.new(*arguments)
+    end
+
+    yield
+    events
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+end
+
+Minitest::Test.include(AdminCommandEventTestHelper)


### PR DESCRIPTION
## Summary
- emit `admin_command.pgbouncerhero` Active Support notifications for every core administrative command
- report successful, unavailable, failed, and read-only-denied outcomes with group, PgBouncer, action, target database, and shutdown mode context
- preserve notification duration while excluding exception objects and database error messages from failure payloads
- route dashboard commands through the instrumented core path and document subscriber integration

## Testing
- `bundle exec rake`
- `bundle exec appraisal rake test`
- `bundle exec rake test:integration`
- `bundle exec rake build`
- coverage for success, unavailable instances, sanitized failures, shutdown modes, global and database-scoped policy denials, and dashboard routing