### PR TITLE
Prepare release 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 3.2.0 - 2026-08-24
+
 **New:**
 - Servers and Users monitoring views for PgBouncer connection and user limits
 - Waiting-client pressure indicators on overview cards from pool `cl_waiting` counts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-PgBouncerHero is a Ruby gem that ships as a **Rails Engine** providing a web dashboard for monitoring and managing one or multiple PgBouncer connection poolers. Version 3.1.0, MIT licensed.
+PgBouncerHero is a Ruby gem that ships as a **Rails Engine** providing a web dashboard for monitoring and managing one or multiple PgBouncer connection poolers. Version 3.2.0, MIT licensed.
 
 ## Requirements
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pgbouncerhero (3.1.0)
+    pgbouncerhero (3.2.0)
       connection_pool (>= 3.0, < 4)
       importmap-rails (>= 1.2, < 3)
       pg (>= 1.2, < 2)
@@ -294,7 +294,7 @@ CHECKSUMS
   pg (1.6.3-x86_64-darwin) sha256=ee2e04a17c0627225054ffeb43e31a95be9d7e93abda2737ea3ce4a62f2729d6
   pg (1.6.3-x86_64-linux) sha256=5d9e188c8f7a0295d162b7b88a768d8452a899977d44f3274d1946d67920ae8d
   pg (1.6.3-x86_64-linux-musl) sha256=9c9c90d98c72f78eb04c0f55e9618fe55d1512128e411035fe229ff427864009
-  pgbouncerhero (3.1.0)
+  pgbouncerhero (3.2.0)
   pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85

--- a/lib/pgbouncerhero/version.rb
+++ b/lib/pgbouncerhero/version.rb
@@ -1,3 +1,3 @@
 module PgBouncerHero
-  VERSION = "3.1.0"
+  VERSION = "3.2.0"
 end

--- a/test/pgbouncerhero_test.rb
+++ b/test/pgbouncerhero_test.rb
@@ -4,7 +4,7 @@ require "tmpdir"
 class PgBouncerHeroTest < Minitest::Test
   def test_version
     assert PgBouncerHero::VERSION
-    assert_equal "3.1.0", PgBouncerHero::VERSION
+    assert_equal "3.2.0", PgBouncerHero::VERSION
   end
 
   def test_config_returns_hash


### PR DESCRIPTION
## Summary
- release the backward-compatible feature work since v3.1.0 as version 3.2.0
- move the accumulated Unreleased notes into a dated 3.2.0 section
- update the gem version, lockfile, project documentation, and version assertion

## SemVer review
No public APIs, routes, configuration keys, runtime requirements, or supported versions were removed. The release adds features and fixes while retaining existing behavior, so a minor version is appropriate.

## Verification
- `bundle exec rake`
- `bundle exec rake test:integration`
- `bundle exec rake build`